### PR TITLE
add vae decoder compare eager graph test

### DIFF
--- a/src/diffusers/models/attention_oneflow.py
+++ b/src/diffusers/models/attention_oneflow.py
@@ -355,7 +355,7 @@ class AttentionBlock(nn.Module):
         return hidden_states
 
     def forward(self, hidden_states):
-        return self._fused_forward(hidden_states)
+        # return self._fused_forward(hidden_states)
         residual = hidden_states
         batch, channel, height, width = hidden_states.shape
 
@@ -616,7 +616,7 @@ class CrossAttention(nn.Module):
         return hidden_states
 
     def forward(self, hidden_states, context=None, mask=None):
-        return self._fused_forward(hidden_states, context=context, mask=context)
+        # return self._fused_forward(hidden_states, context=context, mask=context)
         batch_size, sequence_length, _ = hidden_states.shape
 
         query = self.to_q(hidden_states)


### PR DESCRIPTION
## 新增 vae decoder eager 和 graph 输出对比测试

为了排除 `fused_multi_head_attention_inference` 原子操作的影响，attention 中先注释掉 `_fused_forward`
相关讨论见：https://github.com/Oneflow-Inc/OneTeam/issues/1816#issuecomment-1342214821

### 测试运行方式：

```bash
python3 -m unittest discover -v -s tests/ -p 'test_models_vae_oneflow.py' -k AutoencoderKLTests.test_compare_eager_graph_output &> test_vae.log
```

### 测试思路

首先全部注释掉 `tests/test_models_vae_oneflow.py` 文件开头的所有环境变量设置，然后通过逐个开启，对比输出最大的 diff，来确定是哪个优化导致 eager 和 graph 输出不一致的。

```python3
os.environ["ONEFLOW_MLIR_CSE"] = "1"
os.environ["ONEFLOW_MLIR_ENABLE_INFERENCE_OPTIMIZATION"] = "1"
os.environ["ONEFLOW_MLIR_ENABLE_ROUND_TRIP"] = "1"
os.environ["ONEFLOW_MLIR_FUSE_FORWARD_OPS"] = "1"
os.environ["ONEFLOW_CONV_ALLOW_HALF_PRECISION_ACCUMULATION"] = "1"
os.environ["ONEFLOW_MLIR_GROUP_MATMUL"] = "1"
os.environ["ONEFLOW_MLIR_PREFER_NHWC"] = "1"
```
