### PR TITLE
Compare torch and oneflow output

### DIFF
--- a/tests/compare_of_torch_text_encoder.py
+++ b/tests/compare_of_torch_text_encoder.py
@@ -1,0 +1,41 @@
+import numpy as np
+
+import oneflow as flow
+import torch
+
+from transformers import OneFlowCLIPTextModel, CLIPTextModel
+
+pretrained_model_path = "/home/ldp/.cache/huggingface/diffusers/models--CompVis--stable-diffusion-v1-4/snapshots/a304b1ab1b59dd6c3ba9c40705c29c6de4144096/text_encoder"
+
+of_type = flow.float32
+torch_type = torch.float32
+of_type = flow.float16
+torch_type = torch.float16
+
+loading_kwargs = {'torch_dtype': of_type}
+of_text_encoder = OneFlowCLIPTextModel.from_pretrained(pretrained_model_path, **loading_kwargs)
+of_text_encoder = of_text_encoder.to("cuda")
+loading_kwargs = {'torch_dtype': torch_type}
+torch_text_encoder = CLIPTextModel.from_pretrained(pretrained_model_path, **loading_kwargs)
+torch_text_encoder = torch_text_encoder.to("cuda")
+
+text_ids = np.random.randint(1, 49407, (1, 77), np.int64)
+of_input = flow.tensor(text_ids, device="cuda")
+torch_input = torch.tensor(text_ids, device="cuda")
+
+with flow.no_grad():
+    of_text_embeddings = of_text_encoder(of_input, attention_mask=None)
+    of_text_embeddings = of_text_embeddings[0]
+
+with torch.no_grad():
+    torch_text_embeddings = torch_text_encoder(torch_input, attention_mask=None)
+    torch_text_embeddings = torch_text_embeddings[0]
+
+out_1 = of_text_embeddings.cpu().numpy()
+out_2 = torch_text_embeddings.cpu().numpy()
+out_1 = out_1[~np.isnan(out_1)]
+out_2 = out_2[~np.isnan(out_2)]
+max_diff = np.amax(np.abs(out_1 - out_2))
+print(f"max diff: {max_diff}")
+mean_diff = np.mean(np.abs(out_1 - out_2))
+print(f"mean diff: {mean_diff}")

--- a/tests/compare_of_torch_unet.py
+++ b/tests/compare_of_torch_unet.py
@@ -1,0 +1,61 @@
+import numpy as np
+
+import oneflow as flow
+import torch
+
+from diffusers import OneFlowUNet2DConditionModel, UNet2DConditionModel
+
+pretrained_model_path = "/home/ldp/.cache/huggingface/diffusers/models--CompVis--stable-diffusion-v1-4/snapshots/a304b1ab1b59dd6c3ba9c40705c29c6de4144096/unet"
+
+of_type = flow.float32
+torch_type = torch.float32
+# time step 1:
+# max diff: 0.0015354156494140625
+# mean diff: 0.00029023358365520835
+# time step 50:
+# max diff: 0.3434886932373047
+# mean diff: 0.001315166475251317
+
+# of_type = flow.float16
+# torch_type = torch.float16
+# time step 1:
+# max diff: 0.001953125
+# mean diff: 0.0003502368927001953
+# time step 50:
+# max diff: 0.0625
+# mean diff: 0.0011386871337890625
+
+time_steps = 50
+
+loading_kwargs = {'torch_dtype': of_type}
+of_unet = OneFlowUNet2DConditionModel.from_pretrained(pretrained_model_path, **loading_kwargs)
+of_unet = of_unet.to("cuda")
+loading_kwargs = {'torch_dtype': torch_type}
+torch_unet = UNet2DConditionModel.from_pretrained(pretrained_model_path, **loading_kwargs)
+torch_unet = torch_unet.to("cuda")
+
+noise_np = np.random.rand(2, 4, 64, 64)
+encoder_hidden_states_np = np.random.rand(2, 77, 768)
+
+with flow.no_grad():
+    of_res = flow.tensor(noise_np).to("cuda").to(of_type)
+    encoder_hidden_states = flow.tensor(encoder_hidden_states_np).to("cuda").to(of_type)
+    for t in range(time_steps):
+        t_of = flow.tensor([t]).to("cuda")
+        of_res = of_unet(of_res, t_of, encoder_hidden_states).sample
+
+with torch.no_grad():
+    torch_res = torch.tensor(noise_np).to("cuda").to(torch_type)
+    encoder_hidden_states_torch = torch.tensor(encoder_hidden_states_np).to("cuda").to(torch_type)
+    for t in range(time_steps):
+        t_torch = torch.tensor([t]).to("cuda")
+        torch_res = torch_unet(torch_res, t_torch, encoder_hidden_states_torch).sample
+
+out_1 = of_res.cpu().numpy()
+out_2 = torch_res.cpu().numpy()
+out_1 = out_1[~np.isnan(out_1)]
+out_2 = out_2[~np.isnan(out_2)]
+max_diff = np.amax(np.abs(out_1 - out_2))
+print(f"max diff: {max_diff}")
+mean_diff = np.mean(np.abs(out_1 - out_2))
+print(f"mean diff: {mean_diff}")

--- a/tests/compare_of_torch_vae.py
+++ b/tests/compare_of_torch_vae.py
@@ -1,0 +1,49 @@
+import numpy as np
+
+import oneflow as flow
+import torch
+
+from diffusers import OneFlowAutoencoderKL, AutoencoderKL
+
+pretrained_model_path = "/home/ldp/.cache/huggingface/diffusers/models--CompVis--stable-diffusion-v1-4/snapshots/a304b1ab1b59dd6c3ba9c40705c29c6de4144096/vae"
+
+of_type = flow.float32
+torch_type = torch.float32
+# max diff: 0.003552675247192383
+# mean diff: 4.759765215567313e-05
+
+of_type = flow.float16
+torch_type = torch.float16
+# max diff: 0.013916015625
+# mean diff: 0.0001881122589111328
+
+loading_kwargs = {'torch_dtype': of_type}
+of_vae = OneFlowAutoencoderKL.from_pretrained(pretrained_model_path, **loading_kwargs)
+of_vae = of_vae.to("cuda")
+loading_kwargs = {'torch_dtype': torch_type}
+torch_vae = AutoencoderKL.from_pretrained(pretrained_model_path, **loading_kwargs)
+torch_vae = torch_vae.to("cuda")
+
+np_input = np.random.rand(2, 4, 64, 64)
+of_input = flow.tensor(np_input, device="cuda").to(of_type)
+torch_input = torch.tensor(np_input, device="cuda").to(torch_type)
+
+
+with flow.no_grad():
+    latents = 1 / 0.18215 * of_input
+    of_image = of_vae.decode(latents).sample
+    of_image = (of_image / 2 + 0.5).clamp(0, 1)
+
+with torch.no_grad():
+    latents = 1 / 0.18215 * torch_input
+    torch_image = torch_vae.decode(latents).sample
+    torch_image = (torch_image / 2 + 0.5).clamp(0, 1)
+
+out_1 = of_image.cpu().numpy()
+out_2 = torch_image.cpu().numpy()
+out_1 = out_1[~np.isnan(out_1)]
+out_2 = out_2[~np.isnan(out_2)]
+max_diff = np.amax(np.abs(out_1 - out_2))
+print(f"max diff: {max_diff}")
+mean_diff = np.mean(np.abs(out_1 - out_2))
+print(f"mean diff: {mean_diff}")


### PR DESCRIPTION
oneflow: `'0.8.1.dev20221212+cu112'`
torch: `'1.12.1+cu116'`
TODO
- [x] text encoder
- [x] unet
- [x] vae decoder