### PR TITLE
support mode parameter in  PyTorch 2.1

### DIFF
--- a/src/onediff/infer_compiler/__init__.py
+++ b/src/onediff/infer_compiler/__init__.py
@@ -10,7 +10,7 @@ from .with_fx_interpreter import OneFlowInterpreter
 from .with_fx_graph import fx_node_tranform
 
 
-def oneflow_backend(gm, example_inputs):
+def oneflow_backend(gm, example_inputs, *args, **kwargs):
     with_interp = os.getenv(
         "ONEDIFF_INFER_COMPILER_USE_INTERPRETER", "False"
     ).lower() in ("true", "1", "t",)

--- a/src/onediff/infer_compiler/transform/__init__.py
+++ b/src/onediff/infer_compiler/transform/__init__.py
@@ -6,8 +6,6 @@ from .custom_transform import register
 from .builtin_transform import (
     ProxySubmodule,
     proxy_class,
-    replace_obj,
     map_args,
-    replace_func,
     get_attr,
 )

--- a/src/onediff/infer_compiler/transform/builtin_transform.py
+++ b/src/onediff/infer_compiler/transform/builtin_transform.py
@@ -19,8 +19,6 @@ from functools import singledispatch
 __all__ = [
     "proxy_class",
     "ProxySubmodule",
-    "replace_obj",
-    "replace_func",
     "map_args",
     "get_attr",
     "torch2oflow",
@@ -327,6 +325,8 @@ def _(mod: None, verbose=False):
 def _(mod: types.BuiltinFunctionType, verbose=False):
     if hasattr(mod, "__module__"):
         mod_name = None
+        #TODO: This solution is a compromise for now.
+        #TODO: Should register nn.linear later to solve it elegantly 
         if mod == torch._C._nn.linear:
             return flow.nn.functional.linear
         elif mod.__module__.startswith("torch._C._nn"):
@@ -374,53 +374,9 @@ def _(mod: partial, verbose=False):
 ############################################## Code For Onefx ##############################################
 
 
-def replace_obj(obj):
-    return torch2oflow(obj)
-    cls = type(obj)
-    if obj is None: return obj # fix
-    if cls == torch.dtype:
-        return {
-            "torch.float16": flow.float16,
-            "torch.float32": flow.float32,
-            "torch.double": flow.double,
-            "torch.int8": flow.int8,
-            "torch.int32": flow.int32,
-            "torch.int64": flow.int64,
-            "torch.uint8": flow.uint8,
-        }[str(obj)]
-    if cls == torch.fx.immutable_collections.immutable_list:
-        return [e for e in obj]
-    replacement = proxy_class(cls)
-    if replacement is not None:
-        if cls in [torch.device]:
-            return replacement(str(obj))
-        elif cls == torch.nn.parameter.Parameter:
-            return flow.utils.tensor.from_torch(obj.data)
-        else:
-            raise RuntimeError("don't know how to create oneflow obj for: " + str(cls))
-    else:
-        return obj
-
-
-def replace_func(func):
-    return torch2oflow(func)
-    if func == torch.conv2d:
-        return flow.nn.functional.conv2d
-    if func == torch.conv3d:
-        return flow.nn.functional.conv3d
-    if func == torch._C._nn.linear:
-        return flow.nn.functional.linear
-    if func.__module__.startswith("torch"):
-        mod_name = func.__module__.replace("torch", "oneflow")
-        mod = importlib.import_module(mod_name)
-        return getattr(mod, func.__name__)
-    else:
-        return func
-
-
 def map_args(args, kwargs):
-    args = [replace_obj(a) for a in args]
-    kwargs = dict((k, replace_obj(v)) for (k, v) in kwargs.items())
+    args = [torch2oflow(a) for a in args]
+    kwargs = dict((k, torch2oflow(v)) for (k, v) in kwargs.items())
     return (args, kwargs)
 
 
@@ -428,6 +384,6 @@ def get_attr(gm, node, torch2flow={}):
     attr = getattr(gm, node.target)
     if attr in torch2flow:
         return torch2flow[attr]
-    of_attr = replace_obj(attr)
+    of_attr = torch2oflow(attr)
     torch2flow[attr] = of_attr
     return of_attr

--- a/src/onediff/infer_compiler/transform/builtin_transform.py
+++ b/src/onediff/infer_compiler/transform/builtin_transform.py
@@ -390,7 +390,6 @@ def replace_obj(obj):
         }[str(obj)]
     if cls == torch.fx.immutable_collections.immutable_list:
         return [e for e in obj]
-    print('cls is', cls)
     replacement = proxy_class(cls)
     if replacement is not None:
         if cls in [torch.device]:

--- a/src/onediff/infer_compiler/with_fx_graph.py
+++ b/src/onediff/infer_compiler/with_fx_graph.py
@@ -5,7 +5,7 @@ import oneflow as flow
 from torch.fx.node import map_aggregate
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
-from .transform import replace_obj, replace_func, get_attr, torch2oflow
+from .transform import get_attr, torch2oflow
 
 
 def fx_node_tranform(gm):
@@ -69,7 +69,7 @@ def to_of_transform(
         elif node.op == "call_function":
             of_node = of_g.create_node(
                 "call_function",
-                replace_func(node.target),
+                torch2oflow(node.target),
                 args=node_replace_args(node.args, name2node),
                 kwargs=node_replace_args(node.kwargs, name2node),
             )
@@ -111,7 +111,7 @@ def replace_node(node, name2node):
     if isinstance(node, torch.fx.Node):
         return name2node[node.name]
     else:
-        return replace_obj(node)
+        return torch2oflow(node)
 
 
 def node_replace_args(args, name2node):

--- a/src/onediff/infer_compiler/with_fx_interpreter.py
+++ b/src/onediff/infer_compiler/with_fx_interpreter.py
@@ -1,6 +1,6 @@
 import torch
 from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
-from .transform import map_args, replace_func, ProxySubmodule
+from .transform import map_args, ProxySubmodule
 
 
 class OneFlowInterpreter(torch.fx.Interpreter):
@@ -8,7 +8,7 @@ class OneFlowInterpreter(torch.fx.Interpreter):
 
     def call_function(self, target: Target, args: Tuple, kwargs: Dict) -> Any:
         args, kwargs = map_args(args, kwargs)
-        target = replace_func(target)
+        target = torch2oflow(target)
         return super().call_function(target, args, kwargs)
 
     def call_method(self, target: Target, args: Tuple, kwargs: Dict) -> Any:


### PR DESCRIPTION
修复了--compile_with_dynamo flag下oneflow无法支持PyTorch 2.1的bug
bug复现如下
```
python ~/onediff2/examples/experimental/text_to_image_sdxl_torch_compile.py --compile=false --compile_with_dynamo --base=/share_nfs/hf_models/stable-diffusion-xl-base-1.0
```
bug触发位置
```Python
if cmd_args.compile_with_dynamo:
    print("unet is compiled to oneflow with torch.compile.")
    from onediff.infer_compiler import oneflow_backend

    base.unet = torch.compile(
        base.unet, fullgraph=True, mode="reduce-overhead", backend=oneflow_backend
    )
```
