### PR TITLE
support v1-5-pruned model in sd-webui

### DIFF
--- a/onediff_sd_webui_extensions/compile_ldm.py
+++ b/onediff_sd_webui_extensions/compile_ldm.py
@@ -5,14 +5,18 @@ from onediff.infer_compiler import oneflow_compile, register
 from ldm.modules.attention import BasicTransformerBlock, CrossAttention
 from ldm.modules.diffusionmodules.openaimodel import ResBlock, UNetModel
 from ldm.modules.diffusionmodules.util import GroupNorm32
-from sd_webui_onediff_utils import CrossAttentionOflow, GroupNorm32Oflow, timestep_embedding
+from sd_webui_onediff_utils import (
+    CrossAttentionOflow,
+    GroupNorm32Oflow,
+    timestep_embedding,
+)
 
 __all__ = ["compile_ldm_unet"]
 
 
 # https://github.com/Stability-AI/stablediffusion/blob/b4bdae9916f628461e1e4edbc62aafedebb9f7ed/ldm/modules/diffusionmodules/openaimodel.py#L775
 class UNetModelOflow(flow.nn.Module):
-    def forward(self, x, timesteps=None, context=None, y=None,**kwargs):
+    def forward(self, x, timesteps=None, context=None, y=None, **kwargs):
         assert (y is not None) == (
             self.num_classes is not None
         ), "must specify y if and only if the model is class-conditional"
@@ -43,10 +47,10 @@ torch2oflow_class_map = {
     GroupNorm32: GroupNorm32Oflow,
     UNetModel: UNetModelOflow,
 }
-register(package_names=["ldm"],  torch2oflow_class_map=torch2oflow_class_map)
+register(package_names=["ldm"], torch2oflow_class_map=torch2oflow_class_map)
 
 
-def compile_ldm_unet(sd_model, * ,  use_graph=True, options={}):
+def compile_ldm_unet(sd_model, *, use_graph=True, options={}):
     unet_model = sd_model.model.diffusion_model
     if not isinstance(unet_model, UNetModel):
         return

--- a/onediff_sd_webui_extensions/compile_ldm.py
+++ b/onediff_sd_webui_extensions/compile_ldm.py
@@ -1,0 +1,36 @@
+from onediff.infer_compiler import oneflow_compile, register
+
+import compiled_model
+from ldm.modules.attention import BasicTransformerBlock, CrossAttention
+from ldm.modules.diffusionmodules.openaimodel import ResBlock, UNetModel
+from ldm.modules.diffusionmodules.util import GroupNorm32
+from sd_webui_onediff_utils import CrossAttentionOflow, GroupNorm32Oflow, TimeEmbedModule
+
+torch2oflow_class_map = {
+    CrossAttention: CrossAttentionOflow,
+    GroupNorm32: GroupNorm32Oflow,
+}
+
+import ldm
+register(package_names=[ldm.__path__[0][:-4]],  torch2oflow_class_map=torch2oflow_class_map)
+
+__all__ = ["compile_ldm_unet"]
+
+
+def compile_ldm_unet(sd_model):
+    unet_model = sd_model.model.diffusion_model
+    if not isinstance(unet_model, UNetModel):
+        return
+    for module in unet_model.modules():
+        if isinstance(module, BasicTransformerBlock):
+            module.checkpoint = False
+        if isinstance(module, ResBlock):
+            module.use_checkpoint = False
+    compiled = oneflow_compile(unet_model, use_graph=True)
+    # add ldm package path to sys.path to avoid mock errors
+    import ldm, sys
+    sys.path.append(ldm.__path__[0][:-4])
+    of_model = compiled._deployable_module_model.oneflow_module
+    time_embed_wrapper = TimeEmbedModule(of_model.time_embed)
+    setattr(of_model, "time_embed", time_embed_wrapper)
+    compiled_model.compiled_unet = compiled

--- a/onediff_sd_webui_extensions/compile_ldm.py
+++ b/onediff_sd_webui_extensions/compile_ldm.py
@@ -1,20 +1,61 @@
+import math
+import oneflow as flow
 from onediff.infer_compiler import oneflow_compile, register
 
 import compiled_model
 from ldm.modules.attention import BasicTransformerBlock, CrossAttention
 from ldm.modules.diffusionmodules.openaimodel import ResBlock, UNetModel
 from ldm.modules.diffusionmodules.util import GroupNorm32
-from sd_webui_onediff_utils import CrossAttentionOflow, GroupNorm32Oflow, TimeEmbedModule
+from sd_webui_onediff_utils import CrossAttentionOflow, GroupNorm32Oflow
+
+__all__ = ["compile_ldm_unet"]
+
+
+def timestep_embedding(timesteps, dim, max_period=10000):
+    half = dim // 2
+    freqs = flow.exp(
+        -math.log(max_period) * flow.arange(start=0, end=half, dtype=flow.float32) / half
+    ).to(device=timesteps.device)
+    args = timesteps[:, None].float() * freqs[None]
+    embedding = flow.cat([flow.cos(args), flow.sin(args)], dim=-1)
+    if dim % 2:
+        embedding = flow.cat([embedding, flow.zeros_like(embedding[:, :1])], dim=-1)
+    return embedding
+
+
+class UNetModelOflow(flow.nn.Module):
+    def forward(self, x, timesteps=None, context=None, y=None,**kwargs):
+        assert (y is not None) == (
+            self.num_classes is not None
+        ), "must specify y if and only if the model is class-conditional"
+        hs = []
+        t_emb = timestep_embedding(timesteps, self.model_channels).half()
+        emb = self.time_embed(t_emb)
+        x = x.half()
+        context = context.half()
+        if self.num_classes is not None:
+            assert y.shape[0] == x.shape[0]
+            emb = emb + self.label_emb(y)
+        h = x
+        for module in self.input_blocks:
+            h = module(h, emb, context)
+            hs.append(h)
+        h = self.middle_block(h, emb, context)
+        for module in self.output_blocks:
+            h = flow.cat([h, hs.pop()], dim=1)
+            h = module(h, emb, context)
+        if self.predict_codebook_ids:
+            return self.id_predictor(h)
+        else:
+            return self.out(h)
+
 
 torch2oflow_class_map = {
     CrossAttention: CrossAttentionOflow,
     GroupNorm32: GroupNorm32Oflow,
+    UNetModel: UNetModelOflow,
 }
-
-import ldm
-register(package_names=[ldm.__path__[0][:-4]],  torch2oflow_class_map=torch2oflow_class_map)
-
-__all__ = ["compile_ldm_unet"]
+register(package_names=["ldm"],  torch2oflow_class_map=torch2oflow_class_map)
 
 
 def compile_ldm_unet(sd_model):
@@ -27,10 +68,4 @@ def compile_ldm_unet(sd_model):
         if isinstance(module, ResBlock):
             module.use_checkpoint = False
     compiled = oneflow_compile(unet_model, use_graph=True)
-    # add ldm package path to sys.path to avoid mock errors
-    import ldm, sys
-    sys.path.append(ldm.__path__[0][:-4])
-    of_model = compiled._deployable_module_model.oneflow_module
-    time_embed_wrapper = TimeEmbedModule(of_model.time_embed)
-    setattr(of_model, "time_embed", time_embed_wrapper)
     compiled_model.compiled_unet = compiled

--- a/onediff_sd_webui_extensions/compile_sgm.py
+++ b/onediff_sd_webui_extensions/compile_sgm.py
@@ -1,6 +1,10 @@
 import oneflow as flow
 from onediff.infer_compiler import oneflow_compile, register
-from sd_webui_onediff_utils import CrossAttentionOflow, GroupNorm32Oflow, timestep_embedding
+from sd_webui_onediff_utils import (
+    CrossAttentionOflow,
+    GroupNorm32Oflow,
+    timestep_embedding,
+)
 from sgm.modules.attention import CrossAttention
 from sgm.modules.diffusionmodules.openaimodel import UNetModel
 from sgm.modules.diffusionmodules.util import GroupNorm32
@@ -10,7 +14,7 @@ __all__ = ["compile_sgm_unet"]
 
 # https://github.com/Stability-AI/generative-models/blob/059d8e9cd9c55aea1ef2ece39abf605efb8b7cc9/sgm/modules/diffusionmodules/openaimodel.py#L816
 class UNetModelOflow(flow.nn.Module):
-    def forward(self, x, timesteps=None, context=None, y=None,**kwargs):
+    def forward(self, x, timesteps=None, context=None, y=None, **kwargs):
         assert (y is not None) == (
             self.num_classes is not None
         ), "must specify y if and only if the model is class-conditional"
@@ -43,7 +47,7 @@ torch2oflow_class_map = {
 register(package_names=["sgm"], torch2oflow_class_map=torch2oflow_class_map)
 
 
-def compile_sgm_unet(sd_model, * ,  use_graph=True, options={}):
+def compile_sgm_unet(sd_model, *, use_graph=True, options={}):
     unet_model = sd_model.model.diffusion_model
     if isinstance(unet_model, UNetModel):
         return oneflow_compile(unet_model, use_graph=use_graph, options=options)

--- a/onediff_sd_webui_extensions/compile_sgm.py
+++ b/onediff_sd_webui_extensions/compile_sgm.py
@@ -1,32 +1,49 @@
-import compiled_model
-from onediff.infer_compiler.transform.builtin_transform import torch2oflow
+import oneflow as flow
 from onediff.infer_compiler import oneflow_compile, register
-from sd_webui_onediff_utils import CrossAttentionOflow, GroupNorm32Oflow, TimeEmbedModule
+from sd_webui_onediff_utils import CrossAttentionOflow, GroupNorm32Oflow, timestep_embedding
 from sgm.modules.attention import CrossAttention
+from sgm.modules.diffusionmodules.openaimodel import UNetModel
 from sgm.modules.diffusionmodules.util import GroupNorm32
 
 __all__ = ["compile_sgm_unet"]
 
 
+# https://github.com/Stability-AI/generative-models/blob/059d8e9cd9c55aea1ef2ece39abf605efb8b7cc9/sgm/modules/diffusionmodules/openaimodel.py#L816
+class UNetModelOflow(flow.nn.Module):
+    def forward(self, x, timesteps=None, context=None, y=None,**kwargs):
+        assert (y is not None) == (
+            self.num_classes is not None
+        ), "must specify y if and only if the model is class-conditional"
+        hs = []
+        t_emb = timestep_embedding(timesteps, self.model_channels).half()
+        emb = self.time_embed(t_emb)
+        x = x.half()
+        context = context.half() if context is not None else context
+        y = y.half() if y is not None else y
+        if self.num_classes is not None:
+            assert y.shape[0] == x.shape[0]
+            emb = emb + self.label_emb(y)
+        h = x
+        for module in self.input_blocks:
+            h = module(h, emb, context)
+            hs.append(h)
+        h = self.middle_block(h, emb, context)
+        for module in self.output_blocks:
+            h = flow.cat([h, hs.pop()], dim=1)
+            h = module(h, emb, context)
+        h = h.type(x.dtype)
+        return self.out(h)
+
+
 torch2oflow_class_map = {
     CrossAttention: CrossAttentionOflow,
     GroupNorm32: GroupNorm32Oflow,
+    UNetModel: UNetModelOflow,
 }
 register(package_names=["sgm"], torch2oflow_class_map=torch2oflow_class_map)
 
 
-def compile_sgm_unet(sd_model):
+def compile_sgm_unet(sd_model, * ,  use_graph=True, options={}):
     unet_model = sd_model.model.diffusion_model
-    full_name = f"{unet_model.__module__}.{unet_model.__class__.__name__}"
-    if not full_name.endswith(".UNetModel"):
-        return
-    if full_name.startswith("ldm"):
-        compile_ldm_unet(sd_model)
-    compiled = oneflow_compile(sd_model.model.diffusion_model, use_graph=True)
-    # add sgm package path to sys.path to avoid mock error
-    import sgm, sys
-    sys.path.append(sgm.__path__[0][:-4])
-    time_embed_wrapper = TimeEmbedModule(compiled._deployable_module_model.oneflow_module.time_embed)
-    # https://github.com/Stability-AI/generative-models/blob/e5963321482a091a78375f3aeb2c3867562c913f/sgm/modules/diffusionmodules/openaimodel.py#L984
-    setattr(compiled._deployable_module_model.oneflow_module, "time_embed", time_embed_wrapper)
-    compiled_model.compiled_unet = compiled
+    if isinstance(unet_model, UNetModel):
+        return oneflow_compile(unet_model, use_graph=use_graph, options=options)

--- a/onediff_sd_webui_extensions/compile_sgm.py
+++ b/onediff_sd_webui_extensions/compile_sgm.py
@@ -1,0 +1,32 @@
+import compiled_model
+from onediff.infer_compiler.transform.builtin_transform import torch2oflow
+from onediff.infer_compiler import oneflow_compile, register
+from sd_webui_onediff_utils import CrossAttentionOflow, GroupNorm32Oflow, TimeEmbedModule
+from sgm.modules.attention import CrossAttention
+from sgm.modules.diffusionmodules.util import GroupNorm32
+
+__all__ = ["compile_sgm_unet"]
+
+
+torch2oflow_class_map = {
+    CrossAttention: CrossAttentionOflow,
+    GroupNorm32: GroupNorm32Oflow,
+}
+register(package_names=["sgm"], torch2oflow_class_map=torch2oflow_class_map)
+
+
+def compile_sgm_unet(sd_model):
+    unet_model = sd_model.model.diffusion_model
+    full_name = f"{unet_model.__module__}.{unet_model.__class__.__name__}"
+    if not full_name.endswith(".UNetModel"):
+        return
+    if full_name.startswith("ldm"):
+        compile_ldm_unet(sd_model)
+    compiled = oneflow_compile(sd_model.model.diffusion_model, use_graph=True)
+    # add sgm package path to sys.path to avoid mock error
+    import sgm, sys
+    sys.path.append(sgm.__path__[0][:-4])
+    time_embed_wrapper = TimeEmbedModule(compiled._deployable_module_model.oneflow_module.time_embed)
+    # https://github.com/Stability-AI/generative-models/blob/e5963321482a091a78375f3aeb2c3867562c913f/sgm/modules/diffusionmodules/openaimodel.py#L984
+    setattr(compiled._deployable_module_model.oneflow_module, "time_embed", time_embed_wrapper)
+    compiled_model.compiled_unet = compiled

--- a/onediff_sd_webui_extensions/compiled_model.py
+++ b/onediff_sd_webui_extensions/compiled_model.py
@@ -1,0 +1,2 @@
+"""oneflow_compiled UNetModel"""
+compiled_unet = None

--- a/onediff_sd_webui_extensions/compiled_model.py
+++ b/onediff_sd_webui_extensions/compiled_model.py
@@ -1,2 +1,0 @@
-"""oneflow_compiled UNetModel"""
-compiled_unet = None

--- a/onediff_sd_webui_extensions/install.py
+++ b/onediff_sd_webui_extensions/install.py
@@ -4,7 +4,9 @@ import launch
 def install():
     if not launch.is_installed("oneflow"):
         print("oneflow is not installed! Installing...")
-        launch.run_pip("install --pre oneflow -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/branch/community/cu118")
+        launch.run_pip(
+            "install --pre oneflow -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/branch/community/cu118"
+        )
     if not launch.is_installed("onediff"):
         print("onediff is not installed! Installing...")
         launch.run_pip("install git+https://github.com/siliconflow/onediff.git")

--- a/onediff_sd_webui_extensions/scripts/onediff.py
+++ b/onediff_sd_webui_extensions/scripts/onediff.py
@@ -23,6 +23,7 @@ compiled_unet = None
 def compile(sd_model):
     from ldm.modules.diffusionmodules.openaimodel import UNetModel as UNetModelLDM
     from sgm.modules.diffusionmodules.openaimodel import UNetModel as UNetModelSGM
+
     unet_model = sd_model.model.diffusion_model
     global compiled_unet
     if isinstance(unet_model, UNetModelLDM):
@@ -34,6 +35,7 @@ def compile(sd_model):
 def supplement_sys_path():
     """add package path to sys.path to avoid mock error"""
     import ldm, sgm, sys
+
     sys_paths = set(sys.path)
     new_paths = [sgm.__path__[0][:-4], ldm.__path__[0][:-4]]
     for path in new_paths:

--- a/onediff_sd_webui_extensions/scripts/onediff.py
+++ b/onediff_sd_webui_extensions/scripts/onediff.py
@@ -3,87 +3,24 @@ from modules import script_callbacks
 import modules.shared as shared
 from modules.processing import process_images
 
-import math
 import torch
 import oneflow as flow
-from einops import rearrange
-from oneflow import nn, einsum
-from sgm.modules.attention import default, CrossAttention
+from oneflow import nn
+from sgm.modules.attention import CrossAttention
 from sgm.modules.diffusionmodules.util import GroupNorm32
 from omegaconf import OmegaConf, ListConfig
 from onediff.infer_compiler.transform.builtin_transform import torch2oflow
 from onediff.infer_compiler import oneflow_compile, register
+
+import compiled_model
+from compile_ldm import compile_ldm_unet
+from sd_webui_onediff_utils import CrossAttentionOflow, GroupNorm32Oflow, TimeEmbedModule
 
 
 @torch2oflow.register
 def _(mod, verbose=False) -> ListConfig:
     converted_list = [torch2oflow(item, verbose) for item in mod]
     return OmegaConf.create(converted_list)
-
-
-"""oneflow_compiled UNetModel"""
-_compiled = None
-
-
-
-# https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/sd_hijack_optimizations.py#L142
-# https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/sd_hijack_optimizations.py#L221
-class CrossAttentionOflow(nn.Module):
-    def __init__(
-        self,
-        query_dim,
-        context_dim=None,
-        heads=8,
-        dim_head=64,
-        dropout=0.0,
-        backend=None,
-    ):
-        super().__init__()
-        inner_dim = dim_head * heads
-        context_dim = default(context_dim, query_dim)
-
-        self.scale = dim_head**-0.5
-        self.heads = heads
-
-        self.to_q = nn.Linear(query_dim, inner_dim, bias=False)
-        self.to_k = nn.Linear(context_dim, inner_dim, bias=False)
-        self.to_v = nn.Linear(context_dim, inner_dim, bias=False)
-
-        self.to_out = nn.Sequential(
-            nn.Linear(inner_dim, query_dim), nn.Dropout(dropout)
-        )
-        self.backend = backend
-
-    def forward(
-        self,
-        x,
-        context=None,
-        mask=None,
-        additional_tokens=None,
-        n_times_crossframe_attn_in_self=0,
-    ):
-        h = self.heads
-
-        q_in = self.to_q(x)
-        context = default(context, x)
-
-        # context_k, context_v = hypernetwork.apply_hypernetworks(shared.loaded_hypernetworks, context)
-        context_k, context_v = context, context
-        k_in = self.to_k(context_k)
-        v_in = self.to_v(context_v)
-
-        out = flow._C.fused_multi_head_attention_inference_v2(
-            query=q_in,
-            query_layout="BM(HK)",
-            query_head_size=self.to_q.out_features//self.heads,
-            key=k_in,
-            key_layout="BM(HK)",
-            value=v_in,
-            value_layout="BM(HK)",
-            output_layout="BM(HK)",
-            causal=False,
-        )
-        return self.to_out(out)
 
 
 # https://github.com/Stability-AI/generative-models/blob/e5963321482a091a78375f3aeb2c3867562c913f/sgm/modules/diffusionmodules/wrappers.py#L24
@@ -100,45 +37,28 @@ def forward_wrapper( self, x, t, c, **kwargs):
             )
 
 
-# https://github.com/Stability-AI/generative-models/blob/059d8e9cd9c55aea1ef2ece39abf605efb8b7cc9/sgm/modules/diffusionmodules/util.py#L274
-class GroupNorm32Oflow(nn.GroupNorm):
-    def forward(self, x):
-        # return super().forward(x.float()).type(x.dtype)
-        return super().forward(x).type(x.dtype)
-
-
-# https://github.com/Stability-AI/generative-models/blob/e5963321482a091a78375f3aeb2c3867562c913f/sgm/modules/diffusionmodules/openaimodel.py#L983-L984
-class TimeEmbedModule(nn.Module):
-    def __init__( self, time_embed):
-        super().__init__()
-        self._time_embed_module = time_embed
-
-    def forward(self, t_emb):
-        return self._time_embed_module(t_emb.half())
-
-
 torch2oflow_class_map = {
     CrossAttention: CrossAttentionOflow,
     GroupNorm32: GroupNorm32Oflow,
 }
-
-
 register(package_names=["sgm"], torch2oflow_class_map=torch2oflow_class_map)
 
 
 def compile(sd_model):
     unet_model = sd_model.model.diffusion_model
     full_name = f"{unet_model.__module__}.{unet_model.__class__.__name__}"
-    if full_name != "sgm.modules.diffusionmodules.openaimodel.UNetModel":
+    if not full_name.endswith(".UNetModel"):
         return
-    global _compiled
-    _compiled = oneflow_compile(sd_model.model.diffusion_model, use_graph=True)
+    if full_name.startswith("ldm"):
+        compile_ldm_unet(sd_model)
+    compiled = oneflow_compile(sd_model.model.diffusion_model, use_graph=True)
     # add sgm package path to sys.path to avoid mock error
     import sgm, sys
     sys.path.append(sgm.__path__[0][:-4])
-    time_embed_wrapper = TimeEmbedModule(_compiled._deployable_module_model.oneflow_module.time_embed)
+    time_embed_wrapper = TimeEmbedModule(compiled._deployable_module_model.oneflow_module.time_embed)
     # https://github.com/Stability-AI/generative-models/blob/e5963321482a091a78375f3aeb2c3867562c913f/sgm/modules/diffusionmodules/openaimodel.py#L984
-    setattr(_compiled._deployable_module_model.oneflow_module, "time_embed", time_embed_wrapper)
+    setattr(compiled._deployable_module_model.oneflow_module, "time_embed", time_embed_wrapper)
+    compiled_model.compiled_unet = compiled
 
 
 class Script(scripts.Script):
@@ -149,14 +69,14 @@ class Script(scripts.Script):
         return not is_img2img
 
     def run(self, p):
-        global _compiled
-        if _compiled is None:
+        if compiled_model.compiled_unet is None:
             compile(shared.sd_model)
+        compiled = compiled_model.compiled_unet
         original = shared.sd_model.model.diffusion_model
         from sgm.modules.diffusionmodules.wrappers import OpenAIWrapper
         orig_forward = OpenAIWrapper.forward
-        if _compiled is not None:
-            shared.sd_model.model.diffusion_model = _compiled
+        if compiled is not None:
+            shared.sd_model.model.diffusion_model = compiled
             setattr(OpenAIWrapper, "forward", forward_wrapper)
         proc = process_images(p)
         shared.sd_model.model.diffusion_model = original

--- a/onediff_sd_webui_extensions/sd_webui_onediff_utils.py
+++ b/onediff_sd_webui_extensions/sd_webui_onediff_utils.py
@@ -16,7 +16,9 @@ class GroupNorm32Oflow(nn.GroupNorm):
 def timestep_embedding(timesteps, dim, max_period=10000):
     half = dim // 2
     freqs = flow.exp(
-        -math.log(max_period) * flow.arange(start=0, end=half, dtype=flow.float32) / half
+        -math.log(max_period)
+        * flow.arange(start=0, end=half, dtype=flow.float32)
+        / half
     ).to(device=timesteps.device)
     args = timesteps[:, None].float() * freqs[None]
     embedding = flow.cat([flow.cos(args), flow.sin(args)], dim=-1)
@@ -51,7 +53,7 @@ class CrossAttentionOflow(nn.Module):
         inner_dim = dim_head * heads
         context_dim = default(context_dim, query_dim)
 
-        self.scale = dim_head**-0.5
+        self.scale = dim_head ** -0.5
         self.heads = heads
 
         self.to_q = nn.Linear(query_dim, inner_dim, bias=False)
@@ -83,7 +85,7 @@ class CrossAttentionOflow(nn.Module):
         out = flow._C.fused_multi_head_attention_inference_v2(
             query=q_in,
             query_layout="BM(HK)",
-            query_head_size=self.to_q.out_features//self.heads,
+            query_head_size=self.to_q.out_features // self.heads,
             key=k_in,
             key_layout="BM(HK)",
             value=v_in,

--- a/onediff_sd_webui_extensions/sd_webui_onediff_utils.py
+++ b/onediff_sd_webui_extensions/sd_webui_onediff_utils.py
@@ -1,0 +1,91 @@
+from inspect import isfunction
+
+import oneflow as flow
+from oneflow import nn
+
+
+# https://github.com/Stability-AI/generative-models/blob/059d8e9cd9c55aea1ef2ece39abf605efb8b7cc9/sgm/modules/diffusionmodules/util.py#L274
+# https://github.com/Stability-AI/stablediffusion/blob/b4bdae9916f628461e1e4edbc62aafedebb9f7ed/ldm/modules/diffusionmodules/util.py#L224
+class GroupNorm32Oflow(nn.GroupNorm):
+    def forward(self, x):
+        # return super().forward(x.float()).type(x.dtype)
+        return super().forward(x)
+
+
+# https://github.com/Stability-AI/generative-models/blob/e5963321482a091a78375f3aeb2c3867562c913f/sgm/modules/diffusionmodules/openaimodel.py#L983-L984
+class TimeEmbedModule(nn.Module):
+    def __init__( self, time_embed):
+        super().__init__()
+        self._time_embed_module = time_embed
+
+    def forward(self, t_emb):
+        return self._time_embed_module(t_emb.half())
+
+
+def exists(val):
+    return val is not None
+
+
+def default(val, d):
+    if exists(val):
+        return val
+    return d() if isfunction(d) else d
+
+
+# https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/sd_hijack_optimizations.py#L142
+# https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/master/modules/sd_hijack_optimizations.py#L221
+class CrossAttentionOflow(nn.Module):
+    def __init__(
+        self,
+        query_dim,
+        context_dim=None,
+        heads=8,
+        dim_head=64,
+        dropout=0.0,
+        backend=None,
+    ):
+        super().__init__()
+        inner_dim = dim_head * heads
+        context_dim = default(context_dim, query_dim)
+
+        self.scale = dim_head**-0.5
+        self.heads = heads
+
+        self.to_q = nn.Linear(query_dim, inner_dim, bias=False)
+        self.to_k = nn.Linear(context_dim, inner_dim, bias=False)
+        self.to_v = nn.Linear(context_dim, inner_dim, bias=False)
+
+        self.to_out = nn.Sequential(
+            nn.Linear(inner_dim, query_dim), nn.Dropout(dropout)
+        )
+        self.backend = backend
+
+    def forward(
+        self,
+        x,
+        context=None,
+        mask=None,
+        additional_tokens=None,
+        n_times_crossframe_attn_in_self=0,
+    ):
+        h = self.heads
+
+        q_in = self.to_q(x)
+        context = default(context, x)
+
+        # context_k, context_v = hypernetwork.apply_hypernetworks(shared.loaded_hypernetworks, context)
+        context_k, context_v = context, context
+        k_in = self.to_k(context_k)
+        v_in = self.to_v(context_v)
+        out = flow._C.fused_multi_head_attention_inference_v2(
+            query=q_in,
+            query_layout="BM(HK)",
+            query_head_size=self.to_q.out_features//self.heads,
+            key=k_in,
+            key_layout="BM(HK)",
+            value=v_in,
+            value_layout="BM(HK)",
+            output_layout="BM(HK)",
+            causal=False,
+        )
+        return self.to_out(out)


### PR DESCRIPTION
主要改动
* 修复 [issue: webui 切换模型会报错](https://github.com/siliconflow/onediff/issues/435)。v1-5-pruned 模型对应的代码是 lgm 下的 UNetModel，原先并不支持其编译。
* 重构代码，将编译相关的代码从 Script 中拆出来。
  * sd-webui 在加载插件时，将对应 extension（而不是 scripts） 的目录放到 sys.path。现在可以将代码拆开了。
  * 因为 ldm、sgm、script 都需要访问 model，而 model 只能作为全局变量，所以只能放到一个单独的文件中。
  * 将 ldm、sgm 的 unet 编译分别放到单独的文件。