### PR TITLE
use object.__setattr__ in DualModule and DeployableModule to avoid unexpected key in self._modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ If you need **Enterprise Level Support** for your system or business, please sen
 | HF diffusers            | Yes                 | Yes         |
 | ComfyUI              | Yes           | Yes         |
 | Stable Diffusion web UI | Yes          | Yes         |
-| Multiple Resolutions | Yes(No time cost for most of the cases(       | Yes(Cost a few seconds/minutes to compile for new input shape)           | 
+| Multiple Resolutions | Yes(No time cost for most of the cases)       | Yes(Cost a few seconds/minutes to compile for new input shape)           | 
 | Technical Support for deployment    | High priority support       | Community           | 
 | More Extreme and Dedicated optimization(usually another 20~50% performance gain)         |   Yes         |                 | 
 | Support customized pipeline/workflow|           Yes              | |

--- a/src/onediff/infer_compiler/with_oneflow_compile.py
+++ b/src/onediff/infer_compiler/with_oneflow_compile.py
@@ -420,19 +420,6 @@ def get_oneflow_graph(model, size=9, all_dynamic=False):
     return g
 
 
-def state_dict_hook(module, state_dict, prefix, local_metadata):
-    pytorch_key_prefix = "_deployable_module_model._torch_module."
-    new_state_dict = type(state_dict)()
-    for k, v in state_dict.items():
-        # _deployable_module_model._torch_module.out.2.weight => out.2.weight
-        if k.startswith(pytorch_key_prefix):
-            new_k = k[len(pytorch_key_prefix) :]
-            new_state_dict[new_k] = v
-        else:
-            new_state_dict[k] = v
-    return new_state_dict
-
-
 # Return a DeployableModule that using module_cls as it's parent class.
 def get_mixed_deployable_module(module_cls):
     class MixedDeployableModule(DeployableModule, module_cls):
@@ -489,6 +476,5 @@ def oneflow_compile(
     model = wrap_module(torch_module)
     assert isinstance(model, DeployableModule)
     assert isinstance(model, torch_module.__class__)
-    model._register_state_dict_hook(state_dict_hook)
 
     return model

--- a/tests/test_compiled_model_submodule.py
+++ b/tests/test_compiled_model_submodule.py
@@ -1,0 +1,50 @@
+import numpy as np
+from onediff.infer_compiler import oneflow_compile
+from onediff.infer_compiler.transform import register
+import torch
+import torch.nn as nn
+import oneflow as flow
+
+
+class MyModule(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linears = nn.ModuleList([nn.Linear(10, 10) for i in range(10)])
+
+    def forward(self, x):
+        for i, l in enumerate(self.linears):
+            x = self.linears[i // 2](x) + l(x)
+        return x
+
+
+class MyModuleOneflow(flow.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linears = flow.nn.ModuleList([flow.nn.Linear(10, 10) for i in range(10)])
+
+    def forward(self, x):
+        for i, l in enumerate(self.linears):
+            x = self.linears[i // 2](x) + l(x)
+        return x
+
+def main():
+    register(torch2oflow_class_map={MyModule: MyModuleOneflow})
+
+    torch_module = MyModule().to("cuda")
+    x = torch.randn(2, 10).to("cuda")
+    y_torch = torch_module(x)
+
+    oneflow_module = oneflow_compile(torch_module)
+    y_oneflow = oneflow_module(x)
+
+    for name, of_submodule in oneflow_module.named_modules():
+        torch_submodule = torch_module.get_submodule(name)
+        for param_name, oneflow_param in of_submodule.named_parameters():
+            torch_param = torch_submodule.get_parameter(param_name)
+            assert np.allclose(
+                torch_param.data.detach().cpu().numpy(),
+                oneflow_param.detach().cpu().numpy()
+            )
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_compiled_model_submodule.py
+++ b/tests/test_compiled_model_submodule.py
@@ -46,5 +46,9 @@ def main():
                 oneflow_param.detach().cpu().numpy()
             )
 
+    torch_state_dict = torch_module.state_dict()
+    oneflow_state_dict = oneflow_module.state_dict()
+    assert set(torch_state_dict.keys()) == set(oneflow_state_dict.keys())
+
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
之前直接赋值 `self.xxx = some_nn_Module` 的写法，会在 `self._modules 中写入一个 key='xxx'` 的键值对，这是由于 torch.nn.Module 的 `__setattr__` 决定的，导致遍历、取 state_dict 等行为得到的结果与期望值不符，会多一层不必要的 _torch_module 或者 _deployable_module_model，比如下列场景：
```python3
In [1]: from onediff.infer_compiler import oneflow_compile

In [2]: from torchvision.models.resnet import resnet50

In [3]: model = resnet50(pretrained=False, progress=True).eval()

In [4]: of_model = oneflow_compile(model, use_graph=True)

In [5]: of_model._modules.keys()
Out[5]: odict_keys(['_deployable_module_model'])

In [6]: of_model._deployable_module_model._modules.keys()
Out[6]: odict_keys(['_torch_module'])                                                                                                                                                                                                                       
```

修改之后不用直接赋值语句，而是调用 `object.__setattr__`，避免在 self._modules 中增加不必要的键值对，然后把子 module 中的 _modules、_parameters、_buffers 都浅拷贝一份，这样遍历、state_dict、get_submodule 等行为都正常了