### PR TITLE
remove any existed CI containers before launch the testing ones

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -71,6 +71,7 @@ jobs:
       - name: Setup docker for ComfyUI Test
         if: matrix.test-suite == 'comfy'
         run: |
+          docker compose -f tests/diffusers-docker-compose.yml down --remove-orphans
           docker compose -f tests/comfy-docker-compose.yml up -d
         env:
           CONTAINER_NAME: ${{ env.CONTAINER_NAME }}
@@ -86,6 +87,7 @@ jobs:
       - name: Setup docker for diffusers examples
         if: matrix.test-suite == 'diffusers_examples'
         run: |
+          docker compose -f tests/diffusers-docker-compose.yml down --remove-orphans
           docker compose -f tests/diffusers-docker-compose.yml up -d
         env:
           CONTAINER_NAME: ${{ env.CONTAINER_NAME }}

--- a/tests/comfyui/test_by_ui.py
+++ b/tests/comfyui/test_by_ui.py
@@ -14,6 +14,7 @@ export CONTAINER_NAME=onediff-test
 export SDXL_BASE=/share_nfs/hf_models/sd_xl_base_1.0.safetensors
 export UNET_INT8=/share_nfs/hf_models/unet_int8
 export CONTROL_LORA_OPENPOSEXL2_RANK256=/share_nfs/hf_models/controlnet/control-lora-openposeXL2-rank256.safetensors
+export SILICON_ONEDIFF_LICENSE_KEY=your_license_key
 
 And then:
 
@@ -36,7 +37,7 @@ python tests/comfyui/test_by_ui.py --comfy_port 8188 --workflow tests/comfyui/wo
 
 If you need to shutdown the test containers, run:
 
-docker compose -f tests/comfy-docker-compose.yml down
+docker compose -f tests/comfy-docker-compose.yml down --remove-orphans
 """
 import argparse
 import os


### PR DESCRIPTION
ci 机器上有些时候总是过不了。
初步怀疑是：

1. 某些情况下，容器非正常退出了（不是通过 `docker compose down` 的方式退出的）
2. 所以有些容器只是 stop，并没有被 remove 掉
3. 这样下次 `docker compose up` 会优先使用上次创建的容器。

这个 PR 在启动容器前，先删除掉相关残留容器（`down --remove-orphans`）