### PR TITLE
update readme

### DIFF
--- a/README_ENTERPRISE.md
+++ b/README_ENTERPRISE.md
@@ -10,6 +10,8 @@ OneDiff Enterprise offers a quantization method that reduces memory usage, incre
 
 - [Get the license key](#get-the-license-key)
 - [Install OneDiff Enterprise](#install-onediff-enterprise)
+    - [For NA/EU users](#for-naeu-users)
+    - [For CN users](#for-cn-users)
 - [ComfyUI with OneDiff Enterprise](#comfyui-with-onediff-enterprise)
     - [Accessing ComfyUI Models](#accessing-comfyui-models)
     - [Workflow](#workflow)
@@ -26,22 +28,56 @@ Alternatively, you can [contact](#contact) us to inquire about purchasing the On
 
 ## Install OneDiff Enterprise
 
+### For NA/EU users
+
 **CUDA 11.8**
 
 ```bash
-python3 -m pip install onediff-quant -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff-quant/cu118
+python3 -m pip install --pre oneflow -f https://github.com/siliconflow/oneflow_releases/releases/expanded_assets/enterprise_cu118 && \
+python3 -m pip install --pre onediff-quant -f https://github.com/siliconflow/onediff_releases/releases/expanded_assets/enterprise-cu118 && \
+python3 -m pip install git+https://github.com/siliconflow/onediff.git@main#egg=onediff
 ```
 
 **CUDA 12.1**
 
 ```bash
-python3 -m pip install onediff-quant -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff-quant/cu121
+python3 -m pip install --pre oneflow -f https://github.com/siliconflow/oneflow_releases/releases/expanded_assets/enterprise_cu121 && \
+python3 -m pip install --pre onediff-quant -f https://github.com/siliconflow/onediff_releases/releases/expanded_assets/enterprise-cu121 && \
+python3 -m pip install git+https://github.com/siliconflow/onediff.git@main#egg=onediff
 ```
 
 **CUDA 12.2**
 
 ```bash
-python3 -m pip install onediff-quant -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff-quant/cu122
+python3 -m pip install --pre oneflow -f https://github.com/siliconflow/oneflow_releases/releases/expanded_assets/enterprise_cu122 && \
+python3 -m pip install --pre onediff-quant -f https://github.com/siliconflow/onediff_releases/releases/expanded_assets/enterprise-cu122 && \
+python3 -m pip install git+https://github.com/siliconflow/onediff.git@main#egg=onediff
+```
+
+### For CN users
+
+**CUDA 11.8**
+
+```bash
+python3 -m pip install --pre oneflow -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/branch/main/cu118/ && \
+python3 -m pip install --pre onediff-quant -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff-quant/cu118/ && \
+python3 -m pip install git+https://github.com/siliconflow/onediff.git@main#egg=onediff
+```
+
+**CUDA 12.1**
+
+```bash
+python3 -m pip install --pre oneflow -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/branch/main/cu121/ && \
+python3 -m pip install --pre onediff-quant -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff-quant/cu121/ && \
+python3 -m pip install git+https://github.com/siliconflow/onediff.git@main#egg=onediff
+```
+
+**CUDA 12.2**
+
+```bash
+python3 -m pip install --pre oneflow -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/branch/main/cu122/ && \
+python3 -m pip install --pre onediff-quant -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff-quant/cu122/ && \
+python3 -m pip install git+https://github.com/siliconflow/onediff.git@main#egg=onediff
 ```
 
 ## ComfyUI with OneDiff Enterprise


### PR DESCRIPTION
配合 oneflow 的分区域下载而命令不同，onediff-enterprise 的安装也区分区域。

此外，因为此前的“一键安装”对版本限制太死、对需要梯子的环境报错提示不明显、安装也不方便。因此先回退到三个命令安装的情况。

之后再解决一键安装的问题。