### PR TITLE
rm dynamo

### DIFF
--- a/examples/text_to_image_deep_cache_sdxl_enterprise.py
+++ b/examples/text_to_image_deep_cache_sdxl_enterprise.py
@@ -4,7 +4,6 @@ import time
 
 import torch
 import torch.nn as nn
-from torch._dynamo import allow_in_graph as maybe_allow_in_graph
 
 # oneflow_compile should be imported before importing any diffusers
 from onediff.infer_compiler import oneflow_compile
@@ -112,7 +111,6 @@ for sub_module_name, sub_calibrate_info in calibrate_info.items():
         False,
         False,
         args.bits,
-        maybe_allow_in_graph,
     )
 
 if args.complie_text_encoder:

--- a/examples/text_to_image_sdxl_enterprise.py
+++ b/examples/text_to_image_sdxl_enterprise.py
@@ -4,7 +4,6 @@ import time
 
 import torch
 import torch.nn as nn
-from torch._dynamo import allow_in_graph as maybe_allow_in_graph
 
 # oneflow_compile should be imported before importing any diffusers
 from onediff.infer_compiler import oneflow_compile
@@ -110,7 +109,6 @@ for sub_module_name, sub_calibrate_info in calibrate_info.items():
         False,
         False,
         args.bits,
-        maybe_allow_in_graph,
     )
 
 if args.complie_text_encoder:

--- a/onediff_comfy_nodes/utils/onediff_quant_utils.py
+++ b/onediff_comfy_nodes/utils/onediff_quant_utils.py
@@ -3,7 +3,6 @@ import comfy
 import torch
 import torch.nn as nn
 
-from torch._dynamo import allow_in_graph as maybe_allow_in_graph
 
 if hasattr(comfy.ops, "disable_weight_init"):
     comfy_ops_Linear = comfy.ops.disable_weight_init.Linear
@@ -241,7 +240,6 @@ def replace_module_with_quantizable_module(
             fake_quant=False,
             static=False,
             nbits=8,
-            convert_fn=maybe_allow_in_graph,
         )
         modify_sub_module(diffusion_model, sub_module_name, sub_mod)
     if use_rewrite_attn:

--- a/src/infer_compiler_registry/register_onediff_quant/quant_diffusion_pipeline.py
+++ b/src/infer_compiler_registry/register_onediff_quant/quant_diffusion_pipeline.py
@@ -7,7 +7,6 @@ from onediff_quant.utils import (
     rewrite_sdxl_pipeline_attention,
     replace_sub_module_with_quantizable_module,
 )
-from torch._dynamo import allow_in_graph as maybe_allow_in_graph
 
 
 def _use_graph():
@@ -108,7 +107,6 @@ class QuantDiffusionPipeline:
                 self._fake_quant,
                 self._static,
                 self._bits,
-                maybe_allow_in_graph,
             )
         rewrite_sdxl_pipeline_attention(self._pipe)
 

--- a/src/onediff/optimization/quant_optimizer.py
+++ b/src/onediff/optimization/quant_optimizer.py
@@ -38,7 +38,6 @@ def quantize_model(
     if varify_can_use_quantization() is False:
         return model
 
-    from torch._dynamo import allow_in_graph as maybe_allow_in_graph
     from onediff_quant.utils import symm_quantize_sub_module, find_quantizable_modules
     from onediff_quant.utils import get_quantize_module
     from onediff_quant import Quantizer
@@ -90,7 +89,6 @@ def quantize_model(
                 fake_quant=False,
                 static=False,
                 nbits=bits,
-                convert_fn=maybe_allow_in_graph,
             )
 
             modify_sub_module(model, sub_module_name, sub_mod)


### PR DESCRIPTION
dynamo maybe_allow_in_graph is only used for fx compiler which is deprecated in onediff, so remove it in this PR.