### PR TITLE
make diffusers_extensions.utils a package

### DIFF
--- a/onediff_diffusers_extensions/diffusers_extensions/utils/__init__.py
+++ b/onediff_diffusers_extensions/diffusers_extensions/utils/__init__.py
@@ -1,0 +1,1 @@
+from .lora import load_and_fuse_lora, unfuse_lora


### PR DESCRIPTION
it errors out when importing it right now:
```
2024-01-26 16:33:14.814 [stderr   ]   File "/home/cicero/projects/serverless-registry/registry/image/fast_sdxl/inference.py", line 176, in enable_loras
2024-01-26 16:33:14.814 [stderr   ] ModuleNotFoundError: No module named 'diffusers_extensions.utils'
```