### PR TITLE
add quant_unet

### DIFF
--- a/examples/image_to_image_controlnet.py
+++ b/examples/image_to_image_controlnet.py
@@ -37,6 +37,9 @@ parser.add_argument(
     "--compile_unet", type=(lambda x: str(x).lower() in ["true", "1", "yes"]), default=True
 )
 parser.add_argument(
+    "--quant_unet", type=(lambda x: str(x).lower() in ["true", "1", "yes"]), default=True
+)
+parser.add_argument(
     "--compile_vae", type=(lambda x: str(x).lower() in ["true", "1", "yes"]), default=True
 )
 parser.add_argument(
@@ -69,6 +72,9 @@ pipe.to("cuda")
 
 if args.compile_unet:
     from onediff.infer_compiler import oneflow_compile
+    if args.quant_unet:
+        from onediff.optimization.quant_optimizer import quantize_model
+        pipe.unet = quantize_model(pipe.unet)
     pipe.unet = oneflow_compile(pipe.unet)
 
 if args.compile_vae:

--- a/examples/image_to_image_controlnet.py
+++ b/examples/image_to_image_controlnet.py
@@ -74,9 +74,9 @@ if args.compile_unet:
     from onediff.infer_compiler import oneflow_compile
     if args.quant_unet:
         from onediff.optimization.quant_optimizer import quantize_model
-        pipe.unet = quantize_model(pipe.unet)
+        pipe.unet = quantize_model(pipe.unet, inplace=True)
     pipe.unet = oneflow_compile(pipe.unet)
-
+    torch.cuda.empty_cache()
 if args.compile_vae:
     from onediff.infer_compiler import oneflow_compile
     # ImageToImage has an encoder and decoder, so we need to compile them separately.


### PR DESCRIPTION
```shell 
# cmd: 1
python image_to_image_controlnet.py \
    --base /share_nfs/hf_models/sd-turbo/  \
    --controlnet /share_nfs/hf_models/controlnet-sd21-canny-diffusers  \
    --input_image /share_nfs/hf_models/input_image_vermeer.png \
    --quant_unet 0 \
    --warmup 1 \
    --height 512 \
    --width 512 \
    --saved_image cmd_1.png 

# cmd: 2
python image_to_image_controlnet.py \
    --base /share_nfs/hf_models/sd-turbo/  \
    --controlnet /share_nfs/hf_models/controlnet-sd21-canny-diffusers  \
    --input_image /share_nfs/hf_models/input_image_vermeer.png \
    --quant_unet 1 \
    --warmup 1 \
    --height 512 \
    --width 512 \
    --saved_image cmd_2_quant.png 
```

|  | GPU MEM |
| --- | --- |
|cmd 1 |6680MiB MiB|
| cmd 2 |6164MiB MiB|


- Quantized conv: 66 
- Quantized linear: 216 

<img width="1156" alt="image" src="https://github.com/siliconflow/onediff/assets/109639975/35182b51-23fa-4718-a55f-82007c34f5e3">


## env
- oneflow: version: 0.9.1.dev20240129+cu121 git_commit: 6458a12
cmake_build_type: Release
rdma: True
mlir: True
enterprise: True
- NVIDIA GeForce RTX 3090 