### PR TITLE
Refactor dualmodule._modules

### DIFF
--- a/examples/text_to_image_sdxl.py
+++ b/examples/text_to_image_sdxl.py
@@ -110,14 +110,14 @@ if args.run_multiple_resolutions:
             ).images
 
 
-print("Test run with other another uncommon resolution...")
-if args.run_multiple_resolutions:
-    h = 544
-    w = 408
-    image = base(
-        prompt=args.prompt,
-        height=h,
-        width=w,
-        num_inference_steps=args.n_steps,
-        output_type=OUTPUT_TYPE,
-    ).images
+# print("Test run with other another uncommon resolution...")
+# if args.run_multiple_resolutions:
+#     h = 544
+#     w = 408
+#     image = base(
+#         prompt=args.prompt,
+#         height=h,
+#         width=w,
+#         num_inference_steps=args.n_steps,
+#         output_type=OUTPUT_TYPE,
+#     ).images

--- a/src/onediff/infer_compiler/with_oneflow_compile.py
+++ b/src/onediff/infer_compiler/with_oneflow_compile.py
@@ -20,8 +20,11 @@ from .utils.graph_management_utils import graph_file_management
 class DualModule(torch.nn.Module):
     def __init__(self, torch_module, oneflow_module):
         torch.nn.Module.__init__(self)
-        self._torch_module = torch_module
-        self._oneflow_module = oneflow_module
+        object.__setattr__(self, "_torch_module", torch_module)
+        object.__setattr__(self, "_oneflow_module", oneflow_module)
+        object.__setattr__(self, "_modules", torch_module._modules)
+        # self._torch_module = torch_module
+        # self._oneflow_module = oneflow_module
 
     @property
     def oneflow_module(self):
@@ -190,9 +193,13 @@ class DeployableModule(torch.nn.Module):
         options={},
     ):
         torch.nn.Module.__init__(self)
-        self._deployable_module_model = get_mixed_dual_module(torch_module.__class__)(
+        # self._deployable_module_model = get_mixed_dual_module(torch_module.__class__)(
+        #     torch_module, oneflow_module
+        # )
+        object.__setattr__(self, "_deployable_module_model", get_mixed_dual_module(torch_module.__class__)(
             torch_module, oneflow_module
-        )
+        ))
+        object.__setattr__(self, "_modules", torch_module._modules)
         self._deployable_module_use_graph = use_graph
         self._deployable_module_enable_dynamic = dynamic
         self._deployable_module_options = options

--- a/src/onediff/infer_compiler/with_oneflow_compile.py
+++ b/src/onediff/infer_compiler/with_oneflow_compile.py
@@ -81,9 +81,7 @@ class DualModule(torch.nn.Module):
                 _align_tensor(module, self._oneflow_module.get_submodule(name))
 
     def __getattr__(self, name):
-        if name == "_torch_module":
-            return self._modules[name]
-        if name == "_oneflow_module":
+        if name == "_torch_module" or name == "_oneflow_module":
             return super().__getattribute__(name)
 
         torch_attr = getattr(self._torch_module, name)
@@ -308,8 +306,6 @@ class DeployableModule(torch.nn.Module):
         return output
 
     def __getattr__(self, name):
-        if name in self._modules:
-            return self._modules[name]
         return getattr(self._deployable_module_model, name)
 
     def load_graph(self, file_path, device=None, run_warmup=True):

--- a/src/onediff/infer_compiler/with_oneflow_compile.py
+++ b/src/onediff/infer_compiler/with_oneflow_compile.py
@@ -23,8 +23,6 @@ class DualModule(torch.nn.Module):
         object.__setattr__(self, "_torch_module", torch_module)
         object.__setattr__(self, "_oneflow_module", oneflow_module)
         object.__setattr__(self, "_modules", torch_module._modules)
-        # self._torch_module = torch_module
-        # self._oneflow_module = oneflow_module
 
     @property
     def oneflow_module(self):
@@ -193,9 +191,6 @@ class DeployableModule(torch.nn.Module):
         options={},
     ):
         torch.nn.Module.__init__(self)
-        # self._deployable_module_model = get_mixed_dual_module(torch_module.__class__)(
-        #     torch_module, oneflow_module
-        # )
         object.__setattr__(self, "_deployable_module_model", get_mixed_dual_module(torch_module.__class__)(
             torch_module, oneflow_module
         ))


### PR DESCRIPTION
background: https://github.com/siliconflow/sd-team/issues/191#issue-2063207008
test code:
```python
import oneflow as flow
from onediff.infer_compiler.with_oneflow_compile import oneflow_compile
from onediff.infer_compiler.transform import register
import torch

class Modulelist(torch.nn.Module):
    def __init__(self):
        super().__init__()
        self.module_list = torch.nn.Sequential(
            *[torch.nn.Linear(4, 4, bias=None) for _ in range(5)]
        )

    def forward(self, x):
        return self.module_list(x)

class OfModulelist(flow.nn.Module):
    def __init__(self):
        super().__init__()
        self.module_list = flow.nn.Sequential(
            *[flow.nn.Linear(4, 4, bias=None) for _ in range(5)]
        )

    def forward(self, x):
        return self.module_list(x)

register(torch2oflow_class_map={Modulelist: OfModulelist})

model = Modulelist()
of_model = oneflow_compile(model, use_graph=False)
print("torch enumerate: ", [type(x) for _, x in enumerate(model.module_list)])
print("oneflow enumerate: ", [type(x) for _, x in enumerate(of_model.module_list)])
```

before:
```
torch enumerate:  [<class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.modules.linear.Linear'>]
oneflow enumerate:  [<class 'torch.nn.modules.container.Sequential'>]
```

after:
```
torch enumerate:  [<class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.mo
dules.linear.Linear'>]
oneflow enumerate:  [<class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.modules.linear.Linear'>, <class 'torch.nn.
modules.linear.Linear'>]
```