### PR TITLE
remove sdxl turbo custom scheduler to refine quality

### DIFF
--- a/examples/text_to_image_sdxl_turbo.py
+++ b/examples/text_to_image_sdxl_turbo.py
@@ -10,7 +10,6 @@ import oneflow as flow
 import torch
 
 from onediff.infer_compiler import oneflow_compile
-from onediff.schedulers import EulerDiscreteScheduler
 from diffusers import AutoPipelineForText2Image
 
 parser = argparse.ArgumentParser()
@@ -38,10 +37,8 @@ args = parser.parse_args()
 OUTPUT_TYPE = "pil"
 
 # SDXL turbo base: AutoPipelineForText2Image
-scheduler = EulerDiscreteScheduler.from_pretrained(args.base, subfolder="scheduler")
 base = AutoPipelineForText2Image.from_pretrained(
     args.base,
-    scheduler=scheduler,
     torch_dtype=torch.float16,
     variant=args.variant,
     use_safetensors=True,


### PR DESCRIPTION

## 图片质量

修改前后，结果与 torch 都是对齐的，但是修改后图片质量提高很多。

### 修改前

| torch| onediff|
|----|----|
|![image](https://github.com/siliconflow/onediff/assets/3351623/6bde20dc-bfd1-41f6-9ad9-ea000b9cae80)| ![image](https://github.com/siliconflow/onediff/assets/3351623/3a339e0c-f4d3-4d0c-b939-8f1225173a98)| 


### 修改后

| torch| onediff|
|----|----|
| ![image](https://github.com/siliconflow/onediff/assets/3351623/2c0a3155-2e7c-45f0-ad29-aa2f8be94d28) |  ![image](https://github.com/siliconflow/onediff/assets/3351623/4e14395c-43a1-439b-a2a6-26991f2c7b7d)  | 


## 性能

性能没有影响。

### 修改前

```bash
(base) yaochi@oneflow-28:~/onediff$ python examples/text_to_image_sdxl_turbo.py --compile true --base /share_nfs/hf_mod
els/sdxl-turbo --saved_image old_onediff.png --warmup 10
Loading pipeline components...: 100%|████████████████████████████████████████████████████| 7/7 [00:00<00:00,  9.30it/s]
unet is compiled to oneflow.
vae is compiled to oneflow.
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:49<00:00, 12.26s/it]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 50.45it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 50.47it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 49.81it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 50.74it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 50.53it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 50.81it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 47.68it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 47.62it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 47.55it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 50.04it/s]
e2e (4 steps) elapsed: 0.22461414337158203 s
(base) yaochi@oneflow-28:~/onediff$ python examples/text_to_image_sdxl_turbo.py --compile false --base /share_nfs/hf_mo
dels/sdxl-turbo --saved_image old_onediff.png --warmup 10
Loading pipeline components...: 100%|████████████████████████████████████████████████████| 7/7 [00:00<00:00,  8.18it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  6.44it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.19it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.59it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.56it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.59it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.72it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.67it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.59it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.63it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.75it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.58it/s]
e2e (4 steps) elapsed: 0.39640307426452637 s
```

### 修改后

```bash
(base) yaochi@oneflow-28:~/onediff$ python examples/text_to_image_sdxl_turbo.py --compile true --base /share_nfs/hf_models/sdxl-turbo --saved_image new_onediff.png --warmup 10
Loading pipeline components...: 100%|████████████████████████████████████████████████████| 7/7 [00:00<00:00,  8.80it/s]
unet is compiled to oneflow.
vae is compiled to oneflow.
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:47<00:00, 11.80s/it]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 50.31it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 41.81it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 43.21it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 41.55it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 41.34it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 39.34it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 41.99it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 40.93it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 41.94it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 39.99it/s]
e2e (4 steps) elapsed: 0.2342393398284912 s
(base) yaochi@oneflow-28:~/onediff$ python examples/text_to_image_sdxl_turbo.py --compile false --base /share_nfs/hf_mo
dels/sdxl-turbo --saved_image new_onediff.png --warmup 10
Loading pipeline components...: 100%|████████████████████████████████████████████████████| 7/7 [00:00<00:00,  8.53it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00,  6.10it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 16.10it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 16.00it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.37it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.95it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 16.16it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 15.64it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 16.19it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 16.38it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 16.18it/s]
100%|████████████████████████████████████████████████████████████████████████████████████| 4/4 [00:00<00:00, 16.27it/s]
e2e (4 steps) elapsed: 0.38591837882995605 s
```

