### PR TITLE
Supporting obj is not an object.

### DIFF
--- a/src/onediff/infer_compiler/import_tools/importer.py
+++ b/src/onediff/infer_compiler/import_tools/importer.py
@@ -15,6 +15,8 @@ def is_need_mock(cls) -> bool:
     assert isinstance(cls, (type, str))
     main_pkg = cls.__module__.split(".")[0]
     try:
+        if main_pkg == "torch":
+            return True
         pkgs = requires(main_pkg)
     except Exception as e:
         return True

--- a/src/onediff/infer_compiler/transform/builtin_transform.py
+++ b/src/onediff/infer_compiler/transform/builtin_transform.py
@@ -1,4 +1,5 @@
 """Convert torch object to oneflow object."""
+
 import os
 import importlib
 import types


### PR DESCRIPTION
测试：
```shell
from onediff.infer_compiler.transform import torch2oflow
import torch 
mod = torch.nn.Linear 
# Convert to oneflow
of_mod = torch2oflow(mod)
print(of_mod) # <class 'oneflow.nn.modules.linear.Linear'>
x = 9 
print(f'{isinstance(x, type)=}') # isinstance(x, type)=False
```