### PR TITLE
use EulerAncestralDiscreteScheduler for instant_id and text_to_image

### DIFF
--- a/benchmarks/instant_id.py
+++ b/benchmarks/instant_id.py
@@ -3,7 +3,7 @@ FACE_ANALYSIS_ROOT = None
 MODEL = "wangqixun/YamerMIX_v8"
 VARIANT = None
 CUSTOM_PIPELINE = None
-SCHEDULER = "EulerDiscreteScheduler"
+SCHEDULER = "EulerAncestralDiscreteScheduler"
 LORA = None
 CONTROLNET = "InstantX/InstantID"
 STEPS = 30
@@ -108,12 +108,7 @@ def load_pipe(
         model_name, torch_dtype=torch.float16, **extra_kwargs
     )
     if scheduler is not None:
-        scheduler_cls = getattr(
-            importlib.import_module("onediff.schedulers"), scheduler, None
-        )
-        if scheduler_cls is None:
-            print("No optimized scheduler found, use the plain one.")
-            scheduler_cls = getattr(importlib.import_module("diffusers"), scheduler)
+        scheduler_cls = getattr(importlib.import_module("diffusers"), scheduler)
         pipe.scheduler = scheduler_cls.from_config(pipe.scheduler.config)
     if lora is not None:
         pipe.load_lora_weights(lora)

--- a/benchmarks/text_to_image.py
+++ b/benchmarks/text_to_image.py
@@ -1,7 +1,7 @@
 MODEL = "runwayml/stable-diffusion-v1-5"
 VARIANT = None
 CUSTOM_PIPELINE = None
-SCHEDULER = "EulerDiscreteScheduler"
+SCHEDULER = "EulerAncestralDiscreteScheduler"
 LORA = None
 CONTROLNET = None
 STEPS = 30
@@ -98,12 +98,7 @@ def load_pipe(
         model_name, torch_dtype=torch.float16, **extra_kwargs
     )
     if scheduler is not None:
-        scheduler_cls = getattr(
-            importlib.import_module("onediff.schedulers"), scheduler, None
-        )
-        if scheduler_cls is None:
-            print("No optimized scheduler found, use the plain one.")
-            scheduler_cls = getattr(importlib.import_module("diffusers"), scheduler)
+        scheduler_cls = getattr(importlib.import_module("diffusers"), scheduler)
         pipe.scheduler = scheduler_cls.from_config(pipe.scheduler.config)
     if lora is not None:
         pipe.load_lora_weights(lora)


### PR DESCRIPTION
onediff自带的EulerDiscreteScheduler存在不必要的cuda synchronize开销，且生成图像质量较低，换为EulerAncestralDiscreteScheduler后跑SDXL和instant id有2%的加速效果，且生成图像质量较高。加速效果已在4090和A100上验证