### PR TITLE
fix compatibility with peft and diffusers 0.26.1

### DIFF
--- a/onediff_diffusers_extensions/setup.py
+++ b/onediff_diffusers_extensions/setup.py
@@ -12,7 +12,7 @@ setup(
     python_requires=">=3.7.0",
     install_requires=[
         "transformers>=4.27.1",
-        "diffusers>=0.24.0,<=0.26.1",
+        "diffusers>=0.24.0,<=0.26.2",
         "accelerate",
         "torch",
         "onefx",

--- a/onediff_diffusers_extensions/setup.py
+++ b/onediff_diffusers_extensions/setup.py
@@ -12,7 +12,7 @@ setup(
     python_requires=">=3.7.0",
     install_requires=[
         "transformers>=4.27.1",
-        "diffusers>=0.24.0,<=0.25.1",
+        "diffusers>=0.24.0,<=0.26.1",
         "accelerate",
         "torch",
         "onefx",

--- a/src/infer_compiler_registry/register_diffusers/__init__.py
+++ b/src/infer_compiler_registry/register_diffusers/__init__.py
@@ -20,7 +20,10 @@ if diffusers_version >= version.parse("0.24.00"):
     from diffusers.models.resnet import SpatioTemporalResBlock
     from diffusers.models.transformer_temporal import TransformerSpatioTemporalModel
     from diffusers.models.attention import TemporalBasicTransformerBlock 
-    from diffusers.models.unet_spatio_temporal_condition import UNetSpatioTemporalConditionModel
+    if diffusers_version >= version.parse("0.26.00"):
+        from diffusers.models.unets.unet_spatio_temporal_condition import UNetSpatioTemporalConditionModel
+    else:
+        from diffusers.models.unet_spatio_temporal_condition import UNetSpatioTemporalConditionModel
     
     if diffusers_version >= version.parse("0.25.00"):
         from diffusers.models.autoencoders.autoencoder_kl_temporal_decoder import TemporalDecoder

--- a/src/onediff/infer_compiler/transform/builtin_transform.py
+++ b/src/onediff/infer_compiler/transform/builtin_transform.py
@@ -161,10 +161,6 @@ def _(mod: type):
 
 
 def default_converter(obj, verbose=False, *, proxy_cls=None):
-    # Workaround for Linear and LoRACompatibleLinear.
-    if inspect.isclass(obj):
-        return obj
-
     if not is_need_mock(type(obj)):
         return obj
     try:

--- a/src/onediff/infer_compiler/transform/custom_transform.py
+++ b/src/onediff/infer_compiler/transform/custom_transform.py
@@ -1,8 +1,8 @@
 """A module for registering custom torch2oflow functions and classes."""
 import inspect
+import importlib.util
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
-import importlib.util
 from ..import_tools import import_module_from_path
 from .manager import transform_mgr
 from .builtin_transform import torch2oflow

--- a/src/onediff/infer_compiler/transform/custom_transform.py
+++ b/src/onediff/infer_compiler/transform/custom_transform.py
@@ -2,6 +2,7 @@
 import inspect
 from pathlib import Path
 from typing import Callable, Dict, List, Optional, Union
+import importlib.util
 from ..import_tools import import_module_from_path
 from .manager import transform_mgr
 from .builtin_transform import torch2oflow
@@ -50,16 +51,19 @@ def set_default_registry():
     # compiler_registry_path
     registry_path = Path(__file__).parents[3] / "infer_compiler_registry"
 
-    import_module_safely(registry_path / "register_diffusers", "register_diffusers")
+    if importlib.util.find_spec("diffusers") is not None:
+        import_module_safely(registry_path / "register_diffusers", "register_diffusers")
 
-    import_module_safely(
-        registry_path / "register_onediff_quant", "register_onediff_quant"
-    )
+    if importlib.util.find_spec("onediff_quant") is not None:
+        import_module_safely(
+            registry_path / "register_onediff_quant", "register_onediff_quant"
+        )
 
-    import_module_safely(
-        registry_path / "register_diffusers_enterprise_lite",
-        "register_diffusers_enterprise_lite",
-    )
+    if importlib.util.find_spec("diffusers_enterprise_lite") is not None:
+        import_module_safely(
+            registry_path / "register_diffusers_enterprise_lite",
+            "register_diffusers_enterprise_lite",
+        )
 
 
 def ensure_list(obj):

--- a/src/onediff/infer_compiler/transform/manager.py
+++ b/src/onediff/infer_compiler/transform/manager.py
@@ -26,7 +26,7 @@ class TransformManager:
 
     def _setup_logger(self):
         name = "ONEDIFF"
-        level = logging.DEBUG if self.debug_mode else logging.ERROR
+        level = logging.DEBUG if self.debug_mode else logging.WARNING
         logger.configure_logging(name=name, file_name=None, level=level, log_dir=None)
         self.logger = logger
 

--- a/src/onediff/infer_compiler/utils/log_utils.py
+++ b/src/onediff/infer_compiler/utils/log_utils.py
@@ -37,7 +37,7 @@ class ConfigurableLogger:
 
         # Create a console formatter and add it to a console handler
         console_formatter = ColorFormatter(
-            fmt="%(levelname)s [%(asctime)s] - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
+            fmt="%(levelname)s [%(asctime)s] %(filename)s:%(lineno)d - %(message)s", datefmt="%Y-%m-%d %H:%M:%S"
         )
         console_handler = logging.StreamHandler()
         console_handler.setFormatter(console_formatter)


### PR DESCRIPTION
- Fix converter warning for LoraCompatibleLinear.
- Fix import error for diffusers==0.26.1 which causes patch failure.
- Change default log level to warning to make mistakes more noticeable.
- Check if libs are available before apply patches.