### PR TITLE
dev_support_diffusers_ipa

### DIFF
--- a/src/infer_compiler_registry/register_diffusers/unet_2d_condition_oflow.py
+++ b/src/infer_compiler_registry/register_diffusers/unet_2d_condition_oflow.py
@@ -6,6 +6,7 @@ from onediff.infer_compiler.transform import transform_mgr
 
 diffusers_0210_v = version.parse("0.21.0")
 diffusers_version = version.parse(importlib.metadata.version("diffusers"))
+diffusers_0270_v = version.parse("0.27.0")
 
 transformed_diffusers = transform_mgr.transform_package("diffusers")
 UNet2DConditionOutput = (
@@ -488,3 +489,8 @@ class UNet2DConditionModel(
             return (sample,)
 
         return UNet2DConditionOutput(sample=sample)
+
+
+
+if diffusers_version >= diffusers_0270_v:
+    UNet2DConditionModel = transformed_diffusers.models.unet_2d_condition.UNet2DConditionModel


### PR DESCRIPTION
## Install:
### step 1:  `pip install diffusers==0.27`

### step2: `from diffusers.models.attention_processor import IPAdapterAttnProcessor, IPAdapterAttnProcessor2_0`
      **"Replace the __call__ method of the classes IPAdapterAttnProcessor and IPAdapterAttnProcessor2_0 with forward."**
      https://github.com/huggingface/diffusers/blob/7404f1e9dcdac286caf6ca3cfa43b294f61583bf/src/diffusers/models/attention_processor.py#L2134
      <img width="589" alt="image" src="https://github.com/siliconflow/onediff/assets/109639975/e2932b14-74e7-4767-bfa9-8d7ce1a89b13">


### step3. [OneDiff Installation Guide](https://github.com/siliconflow/onediff/blob/main/README_ENTERPRISE.md#install-onediff-enterprise)
### step4. [OneDiffx Installation Guide](https://github.com/siliconflow/onediff/tree/main/onediff_diffusers_extensions#install-and-setup)


## Usage:

<details open>
<summary> script_00.py </summary>

```python
""" 
### Install
## Prepare environment

You need to complete the following environment dependency installation.

- 1. [OneDiff Installation Guide](https://github.com/siliconflow/onediff/blob/main/README_ENTERPRISE.md#install-onediff-enterprise)
- 2. [OneDiffx Installation Guide](https://github.com/siliconflow/onediff/tree/main/onediff_diffusers_extensions#install-and-setup)

### Usage:
    python script_00.py \
        --model_id "stabilityai/stable-diffusion-xl-base-1.0"\
        --cache_dir "./cache" \
        --num_inference_steps 100 \
        --guidance_scale 7.5 \
        --seed 0 \
        --warmup_steps 3
"""
import os
import argparse
import torch
from diffusers import AutoPipelineForText2Image
from diffusers.utils import load_image as _load_image
from onediffx import compile_pipe, load_pipe, save_pipe

def parse_arguments():
    parser = argparse.ArgumentParser(description="Text-to-Image Generation")
    parser.add_argument("--model_id", default="stabilityai/stable-diffusion-xl-base-1.0", help="Model ID")
    parser.add_argument("--cache_dir", default="./cache", help="Cache directory")
    parser.add_argument("--image", default="https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/diffusers/ip_adapter_diner.png", help="Image URL")
    parser.add_argument("--output", default="output.png", help="Output image filename")
    parser.add_argument("--prompt", default="a polar bear sitting in a chair drinking a milkshake", help="Prompt")
    parser.add_argument("--negative_prompt", default="deformed, ugly, wrong proportion, low res, bad anatomy, worst quality, low quality", help="Negative prompt")
    parser.add_argument("--num_inference_steps", type=int, default=100, help="Number of inference steps")
    parser.add_argument("--guidance_scale", type=float, default=7.5, help="Guidance scale")
    parser.add_argument("--seed", type=int, default=0, help="Random seed")
    parser.add_argument("--warmup_steps", type=int, default=3, help="Number of warmup steps")
    return parser.parse_args()

def load_image(url, cache_dir="."):
    file_name = url.split("/")[-1]
    file_path = os.path.join(cache_dir, file_name)
    if os.path.exists(file_path):
        image = _load_image(file_path)
    else:
        image = _load_image(url)
        image.save(file_path)
    return image

def main():
    # Parse arguments
    args = parse_arguments()
    # Load pre-trained pipeline
    pipe = AutoPipelineForText2Image.from_pretrained(args.model_id, torch_dtype=torch.float16).to("cuda")
    pipe.load_ip_adapter("h94/IP-Adapter", subfolder="sdxl_models", weight_name="ip-adapter_sdxl.bin")
    pipe.set_ip_adapter_scale(0.6)

    # Load images
    image = load_image(args.image)

    # Set up random generator
    generator = torch.Generator(device="cuda").manual_seed(args.seed)

    # Compile and load pipeline
    pipe = compile_pipe(pipe)
    cache_path = os.path.join(args.cache_dir, type(pipe).__name__)
    if os.path.exists(cache_path):
        load_pipe(pipe, cache_path)

    # Run pipeline to generate images
    for _ in range(args.warmup_steps + 1):
        images = pipe(
            prompt=args.prompt,
            ip_adapter_image=image,
            negative_prompt=args.negative_prompt,
            num_inference_steps=args.num_inference_steps,
            guidance_scale=args.guidance_scale,
            generator=generator,
        ).images[0]
    
    # Save generated images
    images.save(args.output)

    # Save compiled pipeline if not already cached
    if not os.path.exists(cache_path):
        os.makedirs(cache_path)
        save_pipe(pipe, cache_path)

if __name__ == "__main__":
    main()

```
</details>
