### PR TITLE
Support 8x resolution by hijacking cat in webui

### DIFF
--- a/onediff_sd_webui_extensions/onediff_hijack.py
+++ b/onediff_sd_webui_extensions/onediff_hijack.py
@@ -1,3 +1,35 @@
+import oneflow
+import compile_ldm
+import compile_sgm
+
+# https://github.com/AUTOMATIC1111/stable-diffusion-webui/blob/1c0a0c4c26f78c32095ebc7f8af82f5c04fca8c0/modules/sd_hijack_unet.py#L8
+class OneFlowHijackForUnet:
+    """
+    This is oneflow, but with cat that resizes tensors to appropriate dimensions if they do not match;
+    this makes it possible to create pictures with dimensions that are multiples of 8 rather than 64
+    """
+
+    def __getattr__(self, item):
+        if item == 'cat':
+            return self.cat
+
+        if hasattr(oneflow, item):
+            return getattr(oneflow, item)
+
+        raise AttributeError(f"'{type(self).__name__}' object has no attribute '{item}'")
+
+    def cat(self, tensors, *args, **kwargs):
+        if len(tensors) == 2:
+            a, b = tensors
+            if a.shape[-2:] != b.shape[-2:]:
+                a = oneflow.nn.functional.interpolate(a, b.shape[-2:], mode="nearest")
+
+            tensors = (a, b)
+
+        return oneflow.cat(tensors, *args, **kwargs)
+
+hijack_flow = OneFlowHijackForUnet()
+
 def unload_model_weights(sd_model=None, info=None):
     from modules import lowvram, devices
     from modules import shared
@@ -26,6 +58,8 @@ def unhijack_function(module, name, new_name):
         delattr(module, new_name)
 
 def do_hijack():
+    compile_ldm.flow = hijack_flow
+    compile_sgm.flow = hijack_flow
     from modules import sd_models, script_callbacks
     script_callbacks.on_script_unloaded(undo_hijack)
     hijack_function(
@@ -42,6 +76,8 @@ def do_hijack():
     )
 
 def undo_hijack():
+    compile_ldm.flow = oneflow
+    compile_sgm.flow = oneflow
     from modules import sd_models
     unhijack_function(
         module=sd_models,


### PR DESCRIPTION
存在的问题：在 sd-webui 中，onediff 仅支持 64 倍分辨率的图片，对应的 issue 是 https://github.com/siliconflow/onediff/issues/832 （本质原因是，非 64 倍分辨率时，unet 上下采样所产生的张量维度误差会导致 `cat` 操作失败）。

解决方法：发现 sd-webui 是通过劫持 `torch.cat` 来应对这一问题以支持 8 倍分辨率的，所以对应地，只需要在 onediff 中对 `oneflow.cat` 进行劫持即可。 