### PR TITLE
fix removeprefix for python 3.8

### DIFF
--- a/onediff_comfy_nodes/extras_nodes/nodes_compare.py
+++ b/onediff_comfy_nodes/extras_nodes/nodes_compare.py
@@ -66,9 +66,11 @@ class CompareModel:
             )
             return {}
 
+        removeprefix = lambda ss, prefix: ss[len(prefix):] if ss.startswith(prefix) else ss
+        
         cnt = 0
         for key, _ in oflow_unet.named_parameters():
-            key = key.removeprefix("_deployable_module_model._torch_module.")
+            key = removeprefix(key, "_deployable_module_model._torch_module.")
             torch_value = torch_unet.get_parameter(key).cuda()
             oflow_value = oflow_unet._deployable_module_model._oneflow_module.get_parameter(
                 key

--- a/src/onediff/infer_compiler/utils/param_utils.py
+++ b/src/onediff/infer_compiler/utils/param_utils.py
@@ -80,10 +80,14 @@ def set_constant_folded_conv_attr(
 def generate_constant_folding_info(
     deployable_module, torch_module: torch.nn.Module = None
 ) -> Dict[str, flow.Tensor]:
+    removeprefix = lambda ss, prefix: ss[len(prefix):] if ss.startswith(prefix) else ss
+    
     # convert str like 'variable_transpose_model.input_blocks.10.0.in_layers.2.weight_239'
     # to 'input_blocks.10.0.in_layers.2.weight'
     def convert_var_name(s: str, prefix="variable_transpose_"):
-        s = re.sub(r"_[0-9]+$", "", s.removeprefix(prefix)).removeprefix("model.")
+        s = removeprefix(s, prefix)
+        s = re.sub(r"_[0-9]+$", "", s)
+        s = removeprefix(s, "model.")
         return s
 
     from onediff.infer_compiler.deployable_module import DeployableModule


### PR DESCRIPTION
The python versions supported by onediff are 3.8~3.11, while `removeprefix` was introduced in 3.9.