### PR TITLE
fix deepcache unet error in comfyui

### DIFF
--- a/onediff_comfy_nodes/modules/oneflow/infer_compiler_registry/register_comfy/deep_cache_unet.py
+++ b/onediff_comfy_nodes/modules/oneflow/infer_compiler_registry/register_comfy/deep_cache_unet.py
@@ -119,7 +119,7 @@ class DeepCacheUNet(Module):
             h = torch.cat([h, hsp], dim=1)
             del hsp
             if len(hs) > 0:
-                output_shape = hs[-1].shape
+                output_shape = h[-1]
             else:
                 output_shape = None
             h = forward_timestep_embed(
@@ -246,7 +246,7 @@ class FastDeepCacheUNet(Module):
             h = torch.cat([h, hsp], dim=1)
             del hsp
             if len(hs) > 0:
-                output_shape = hs[-1].shape
+                output_shape = h[-1]
             else:
                 output_shape = None
             h = forward_timestep_embed(

--- a/onediff_comfy_nodes/modules/oneflow/infer_compiler_registry/register_comfy/deep_cache_unet.py
+++ b/onediff_comfy_nodes/modules/oneflow/infer_compiler_registry/register_comfy/deep_cache_unet.py
@@ -119,7 +119,7 @@ class DeepCacheUNet(Module):
             h = torch.cat([h, hsp], dim=1)
             del hsp
             if len(hs) > 0:
-                output_shape = h[-1]
+                output_shape = hs[-1]
             else:
                 output_shape = None
             h = forward_timestep_embed(
@@ -246,7 +246,7 @@ class FastDeepCacheUNet(Module):
             h = torch.cat([h, hsp], dim=1)
             del hsp
             if len(hs) > 0:
-                output_shape = h[-1]
+                output_shape = hs[-1]
             else:
                 output_shape = None
             h = forward_timestep_embed(

--- a/onediff_sd_webui_extensions/onediff_hijack.py
+++ b/onediff_sd_webui_extensions/onediff_hijack.py
@@ -8,24 +8,18 @@ class OneFlowHijackForUnet:
     This is oneflow, but with cat that resizes tensors to appropriate dimensions if they do not match;
     this makes it possible to create pictures with dimensions that are multiples of 8 rather than 64
     """
-
     def __getattr__(self, item):
         if item == 'cat':
             return self.cat
-
         if hasattr(oneflow, item):
             return getattr(oneflow, item)
-
         raise AttributeError(f"'{type(self).__name__}' object has no attribute '{item}'")
 
     def cat(self, tensors, *args, **kwargs):
         if len(tensors) == 2:
             a, b = tensors
-            if a.shape[-2:] != b.shape[-2:]:
-                a = oneflow.nn.functional.interpolate(a, b.shape[-2:], mode="nearest")
-
+            a = oneflow.nn.functional.interpolate_like(a, like=b, mode="nearest")
             tensors = (a, b)
-
         return oneflow.cat(tensors, *args, **kwargs)
 
 hijack_flow = OneFlowHijackForUnet()


### PR DESCRIPTION
对 issue https://github.com/siliconflow/onediff/issues/857 以及 https://github.com/siliconflow/onediff/issues/778 的修复。

#### 说明
修改后，`output_shape = hs[-1]` 是让 `Upsample` 进入到：https://github.com/siliconflow/onediff/blob/4852e8a3aa254ae248e12ce4863d0a332f858a15/onediff_comfy_nodes/modules/oneflow/infer_compiler_registry/register_comfy/openaimodel.py#L20
即最终调用 `interpolate_like` 而非另一个条件下的 `interpolate`。

这样，`DeepCacheUNet / FastDeepCacheUNet` 也与 `UNetModel` 保持一致了：https://github.com/siliconflow/onediff/blob/4852e8a3aa254ae248e12ce4863d0a332f858a15/onediff_comfy_nodes/modules/oneflow/infer_compiler_registry/register_comfy/openaimodel.py#L145