### PR TITLE
[WIP] Add nexfort backend dynamic shape example

### DIFF
--- a/onediff_diffusers_extensions/examples/text_to_image_sdxl.py
+++ b/onediff_diffusers_extensions/examples/text_to_image_sdxl.py
@@ -1,15 +1,20 @@
 """
 Torch run example: python examples/text_to_image_sdxl.py
-Compile to oneflow graph example: python examples/text_to_image_sdxl.py
+Compile with oneflow: python examples/text_to_image_sdxl.py --compiler oneflow
+Compile with nexfort: python examples/text_to_image_sdxl.py --compiler nexfort
+Test dynamic shape: Add --run_multiple_resolutions 1 and --run_rare_resolutions 1
 """
 import os
+import json
+import time
 import argparse
 
 import torch
 import oneflow as flow
 
-from onediff.infer_compiler import oneflow_compile
+# from onediff.infer_compiler import oneflow_compile
 from onediff.schedulers import EulerDiscreteScheduler
+from onediffx import compile_pipe, CompileOptions
 from diffusers import StableDiffusionXLPipeline
 
 parser = argparse.ArgumentParser()
@@ -22,20 +27,31 @@ parser.add_argument(
     type=str,
     default="street style, detailed, raw photo, woman, face, shot on CineStill 800T",
 )
-parser.add_argument("--height", type=int, default=1024)
-parser.add_argument("--width", type=int, default=1024)
+parser.add_argument("--height", type=int, default=512)
+parser.add_argument("--width", type=int, default=768)
 parser.add_argument("--n_steps", type=int, default=30)
 parser.add_argument("--saved_image", type=str, required=False, default="sdxl-out.png")
 parser.add_argument("--seed", type=int, default=1)
+# parser.add_argument(
+#     "--compile_unet",
+#     type=(lambda x: str(x).lower() in ["true", "1", "yes"]),
+#     default=True,
+# )
+# parser.add_argument(
+#     "--compile_vae",
+#     type=(lambda x: str(x).lower() in ["true", "1", "yes"]),
+#     default=True,
+# )
 parser.add_argument(
-    "--compile_unet",
-    type=(lambda x: str(x).lower() in ["true", "1", "yes"]),
-    default=True,
+    "--compiler",
+    type=str,
+    default="oneflow",
+    choices=["oneflow", "nexfort"],
 )
 parser.add_argument(
-    "--compile_vae",
-    type=(lambda x: str(x).lower() in ["true", "1", "yes"]),
-    default=True,
+    "--compiler-config",
+    type=str,
+    default=None,
 )
 parser.add_argument(
     "--run_multiple_resolutions",
@@ -63,15 +79,31 @@ base = StableDiffusionXLPipeline.from_pretrained(
 )
 base.to("cuda")
 
-# Compile unet with oneflow
-if args.compile_unet:
-    print("Compiling unet with oneflow.")
-    base.unet = oneflow_compile(base.unet)
+# # Compile unet with oneflow
+# if args.compile_unet:
+#     print("Compiling unet with oneflow.")
+#     base.unet = oneflow_compile(base.unet)
 
-# Compile vae with oneflow
-if args.compile_vae:
-    print("Compiling vae with oneflow.")
-    base.vae.decoder = oneflow_compile(base.vae.decoder)
+# # Compile vae with oneflow
+# if args.compile_vae:
+#     print("Compiling vae with oneflow.")
+#     base.vae.decoder = oneflow_compile(base.vae.decoder)
+
+# Compile the pipe
+if args.compiler == "oneflow":
+    base = compile_pipe(base)
+elif args.compiler == "nexfort":
+    options = CompileOptions()
+    if args.compiler_config is not None:
+        options.nexfort = json.loads(args.compiler_config)
+    else:
+        options.nexfort = json.loads(
+            '{"mode": "max-autotune:cudagraphs", "dynamic": true}'
+        )
+
+    base = compile_pipe(
+        base, backend="nexfort", options=options, fuse_qkv_projections=True
+    )
 
 # Warmup with run
 # Will do compilatioin in the first run
@@ -88,6 +120,8 @@ image = base(
 # Normal SDXL run
 print("Normal SDXL run...")
 torch.manual_seed(args.seed)
+print(f"Running at resolution: {args.height}x{args.width}")
+start_time = time.time()
 image = base(
     prompt=args.prompt,
     height=args.height,
@@ -95,6 +129,8 @@ image = base(
     num_inference_steps=args.n_steps,
     output_type=OUTPUT_TYPE,
 ).images
+end_time = time.time()
+print(f"Inference time: {end_time - start_time:.2f} seconds")
 image[0].save(f"h{args.height}-w{args.width}-{args.saved_image}")
 
 
@@ -106,6 +142,8 @@ if args.run_multiple_resolutions:
         sizes = [360]
     for h in sizes:
         for w in sizes:
+            print(f"Running at resolution: {h}x{w}")
+            start_time = time.time()
             image = base(
                 prompt=args.prompt,
                 height=h,
@@ -113,12 +151,16 @@ if args.run_multiple_resolutions:
                 num_inference_steps=args.n_steps,
                 output_type=OUTPUT_TYPE,
             ).images
+            end_time = time.time()
+            print(f"Inference time: {end_time - start_time:.2f} seconds")
 
 
 if args.run_rare_resolutions:
     print("Test run with other another uncommon resolution...")
     h = 544
     w = 408
+    print(f"Running at resolution: {h}x{w}")
+    start_time = time.time()
     image = base(
         prompt=args.prompt,
         height=h,
@@ -126,3 +168,5 @@ if args.run_rare_resolutions:
         num_inference_steps=args.n_steps,
         output_type=OUTPUT_TYPE,
     ).images
+    end_time = time.time()
+    print(f"Inference time: {end_time - start_time:.2f} seconds")


### PR DESCRIPTION
log:
可以发现，720x960 和 960x720 还是有明显的编译开销。

```
(onediff_nexfort) lixiang@h001:~/onediff$ python3 onediff_diffusers_extensions/examples/text_to_image_sdxl.py --compiler nexfort --run_multiple_resolutions 1 --run_rare_resolutions 1
Loading pipeline components...: 100%|██████████████████████████████████████████████████████████████| 7/7 [00:00<00:00,  9.23it/s]
****** fuse qkv projections ******
Warmup with running graphs...
[2024-05-24 15:35:02,395] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
[2024-05-24 15:35:16,133] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:39:45,999] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [04:37<00:00,  9.25s/it]
[2024-05-24 15:40:15,282] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Normal SDXL run...
Running at resolution: 512x768
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:00<00:00, 64.84it/s]
Inference time: 0.59 seconds
Test run with multiple resolutions...
Running at resolution: 960x960
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:40:18,017] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:02<00:00, 13.21it/s]
[2024-05-24 15:40:20,293] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 3.37 seconds
Running at resolution: 960x720
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:44:35,730] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [04:21<00:00,  8.72s/it]
[2024-05-24 15:44:43,131] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 264.16 seconds
Running at resolution: 960x896
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:44:45,545] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  8.86it/s]
[2024-05-24 15:44:48,935] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 5.91 seconds
Running at resolution: 960x768
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:44:51,452] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  9.17it/s]
[2024-05-24 15:44:54,727] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.01 seconds
Running at resolution: 720x960
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:48:51,878] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [03:58<00:00,  7.94s/it]
[2024-05-24 15:48:55,808] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 241.26 seconds
Running at resolution: 720x720
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:48:58,730] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  8.74it/s]
[2024-05-24 15:49:02,167] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.33 seconds
Running at resolution: 720x896
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:49:05,055] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  8.68it/s]
[2024-05-24 15:49:08,515] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.33 seconds
Running at resolution: 720x768
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:49:11,382] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  8.67it/s]
[2024-05-24 15:49:14,845] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.32 seconds
Running at resolution: 896x960
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:49:17,704] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  7.73it/s]
[2024-05-24 15:49:21,588] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.74 seconds
Running at resolution: 896x720
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:49:24,448] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  8.66it/s]
[2024-05-24 15:49:27,913] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.38 seconds
Running at resolution: 896x896
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:49:30,831] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  7.87it/s]
[2024-05-24 15:49:34,645] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.72 seconds
Running at resolution: 896x768
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:49:37,551] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  8.47it/s]
[2024-05-24 15:49:41,094] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.44 seconds
Running at resolution: 768x960
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:49:43,992] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  8.38it/s]
[2024-05-24 15:49:47,577] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.55 seconds
Running at resolution: 768x720
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:49:50,539] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  8.62it/s]
[2024-05-24 15:49:54,024] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.35 seconds
Running at resolution: 768x896
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:49:56,890] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  8.54it/s]
[2024-05-24 15:50:00,404] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.40 seconds
Running at resolution: 768x768
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:50:03,294] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:03<00:00,  8.66it/s]
[2024-05-24 15:50:06,762] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 6.37 seconds
Test run with other another uncommon resolution...
Running at resolution: 544x408
  0%|                                                                                                     | 0/30 [00:00<?, ?it/s][2024-05-24 15:50:09,666] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
100%|████████████████████████████████████████████████████████████████████████████████████████████| 30/30 [00:02<00:00, 10.80it/s]
[2024-05-24 15:50:12,894] [INFO] [external_utils.py:36:inner] Dynamically CUDA graphing ModuleToBeGraphed
Inference time: 5.98 seconds
```