### PR TITLE
[fix bug] OneDiffX `load_and_fuse_lora` when `lora_scale == 0` makes w_up to allzeros

### DIFF
--- a/onediff_diffusers_extensions/onediffx/lora/lora.py
+++ b/onediff_diffusers_extensions/onediffx/lora/lora.py
@@ -75,6 +75,7 @@ def load_and_fuse_lora(
         raise ValueError("[OneDiffX load_and_fuse_lora] Invalid LoRA checkpoint.")
 
     # load lora into unet
+    # import ipdb; ipdb.set_trace()
     load_lora_into_unet(
         self,
         state_dict,

--- a/onediff_diffusers_extensions/onediffx/lora/lora.py
+++ b/onediff_diffusers_extensions/onediffx/lora/lora.py
@@ -75,7 +75,6 @@ def load_and_fuse_lora(
         raise ValueError("[OneDiffX load_and_fuse_lora] Invalid LoRA checkpoint.")
 
     # load lora into unet
-    # import ipdb; ipdb.set_trace()
     load_lora_into_unet(
         self,
         state_dict,

--- a/onediff_diffusers_extensions/onediffx/lora/utils.py
+++ b/onediff_diffusers_extensions/onediffx/lora/utils.py
@@ -77,6 +77,8 @@ def get_delta_weight(
     w_down: torch.Tensor,
     weight: float,
 ):
+    if weight == 0:
+        return torch.zeros_like(self.weight, dtype=self.weight.dtype, device=self.weight.device)
 
     if isinstance(self, (torch.nn.Linear, PatchedLoraProjection)):
         lora_weight = torch.bmm(w_up[None, :], w_down[None, :])[0]
@@ -123,17 +125,17 @@ def _set_adapter(self, adapter_names, adapter_weights):
             continue
 
         self.active_adapter_names[adapter] = weight
+        self.scaling[adapter] = weight * self.lora_alpha[adapter] / self.r[adapter]
         w_down = self.lora_A[adapter].float().to(device)
         w_up = self.lora_B[adapter].float().to(device)
         if delta_weight is None:
             delta_weight = get_delta_weight(
-                self, w_up, w_down, weight / self.scaling[adapter]
+                self, w_up, w_down, self.scaling[adapter]
             )
         else:
             delta_weight += get_delta_weight(
-                self, w_up, w_down, weight / self.scaling[adapter]
+                self, w_up, w_down, self.scaling[adapter]
             )
-        self.active_adapter_names[adapter] = weight
 
     if delta_weight is not None:
         fused_weight = self.weight.data.float() + delta_weight
@@ -210,21 +212,26 @@ def fuse_lora(
     w_down = state_dict[down_key].float().to(device)
     w_up = state_dict[up_key].float().to(device)
 
-    if alpha is not None:
-        w_up = w_up * (alpha / rank * lora_scale)
+    # if alpha is not None:
+    #     w_up = w_up * (alpha / rank)
 
     adapter_name = adapter_name if adapter_name is not None else get_adapter_names(self)
 
+    if alpha is None:
+        alpha = rank
+    #     self.scaling[adapter_name] = lora_scale
+    # else:
+
+    self.scaling[adapter_name] = lora_scale * alpha / rank
     self.r[adapter_name] = rank
     self.lora_alpha[adapter_name] = alpha
-    self.scaling[adapter_name] = lora_scale
     self.lora_A[adapter_name] = offload_tensor(w_down, offload_device)
     self.lora_B[adapter_name] = offload_tensor(w_up, offload_device)
     self.adapter_names.add(adapter_name)
-    self.active_adapter_names[adapter_name] = 1.0
+    self.active_adapter_names[adapter_name] = lora_scale
 
     if fuse:
-        lora_weight = get_delta_weight(self, w_up, w_down, 1.0)
+        lora_weight = get_delta_weight(self, w_up, w_down, self.scaling[adapter_name])
         fused_weight = self.weight.data.float() + lora_weight
         self.weight.data.copy_(fused_weight.to(device=device, dtype=dtype))
         update_graph_related_tensor(self)
@@ -252,15 +259,15 @@ def _unfuse_lora(
     for name in adapter_names:
         if name not in self.active_adapter_names:
             continue
-        weight = self.active_adapter_names[name]
+        # weight = self.active_adapter_names[name]
         w_down = self.lora_A[name].to(device=device).float()
         w_up = self.lora_B[name].to(device).float()
         if delta_weight is None:
-            delta_weight = get_delta_weight(self, w_up, w_down, weight).to(
+            delta_weight = get_delta_weight(self, w_up, w_down, self.scaling[name]).to(
                 dtype=dtype, device=device
             )
         else:
-            delta_weight += get_delta_weight(self, w_up, w_down, weight).to(
+            delta_weight += get_delta_weight(self, w_up, w_down, self.scaling[name]).to(
                 dtype=dtype, device=device
             )
         self.active_adapter_names.pop(name)

--- a/onediff_diffusers_extensions/onediffx/lora/utils.py
+++ b/onediff_diffusers_extensions/onediffx/lora/utils.py
@@ -212,15 +212,10 @@ def fuse_lora(
     w_down = state_dict[down_key].float().to(device)
     w_up = state_dict[up_key].float().to(device)
 
-    # if alpha is not None:
-    #     w_up = w_up * (alpha / rank)
-
     adapter_name = adapter_name if adapter_name is not None else get_adapter_names(self)
 
     if alpha is None:
         alpha = rank
-    #     self.scaling[adapter_name] = lora_scale
-    # else:
 
     self.scaling[adapter_name] = lora_scale * alpha / rank
     self.r[adapter_name] = rank
@@ -259,7 +254,6 @@ def _unfuse_lora(
     for name in adapter_names:
         if name not in self.active_adapter_names:
             continue
-        # weight = self.active_adapter_names[name]
         w_down = self.lora_A[name].to(device=device).float()
         w_up = self.lora_B[name].to(device).float()
         if delta_weight is None:


### PR DESCRIPTION
LoRA 加载有如下参数：
1. B 矩阵 (m x r) 和 A 矩阵 (r x n)，也就是 lora_down 和 lora_up
2. alpha 用来控制 LoRA 在模型中的权重
3. rank 也就是 1. 中的 r

计算是 weight += B@A * alpha / rank * lora_scale。如果 LoRA 中没有 alpha 这个参数，那么计算就变成 weight += B@A * scale。

bug：之前为了节省计算量，把A * alpha / rank * scale 直接保存成了 A，对于 scale=0 的输入，A 就变成了全 0 的矩阵

我看了 peft 里面和 lora_alpha 有关的计算，这里都没有判断是否为 None，说明 lora_alpha 传到这里都是有值的
然后又看了 diffusers 调用 peft 的部分，这里设定了 lora_alpha 默认和 r 相等
https://github.com/huggingface/diffusers/blob/main/src/diffusers/utils/peft_utils.py#L150-L153
所以修复方式是 A 不使用这种耍小聪明的方式保存，而是保存原来的矩阵，把标量乘法的融合放在 alpha / rank * lora_scale 这里做