### PR TITLE
Fix VaeSpeedup node and Support multiple model cache

### DIFF
--- a/onediff_comfy_nodes/_nodes.py
+++ b/onediff_comfy_nodes/_nodes.py
@@ -92,6 +92,9 @@ class VaeSpeedup(SpeedupMixin):
         }
 
     RETURN_TYPES = ("VAE",)
+    
+    def speedup(self, vae, inplace=False, custom_booster: BoosterScheduler = None):
+        return super().speedup(vae, inplace, custom_booster)
 
 
 class ControlnetSpeedup:


### PR DESCRIPTION
1. 修复 VaeSpeedup 节点的参数名不一致问题。
2. 在 ModelPatcher 基础上，增加了 VAE、ControlNet 和 ControlLora 的 cache 支持。