### PR TITLE
[minor-fix] Update booster_cache.py to import utility

### DIFF
--- a/onediff_comfy_nodes/modules/booster_cache.py
+++ b/onediff_comfy_nodes/modules/booster_cache.py
@@ -5,7 +5,7 @@ import torch
 from comfy.model_patcher import ModelPatcher
 from comfy.sd import VAE
 from onediff.torch_utils.module_operations import get_sub_module
-
+from onediff.utils.import_utils import is_oneflow_available
 
 @singledispatch
 def switch_to_cached_model(new_model, cached_model):


### PR DESCRIPTION
`NameError: name 'is_oneflow_available' is not defined`

```
model_type EPS
Using pytorch attention in VAE
Using pytorch attention in VAE
clip missing: ['clip_l.logit_scale', 'clip_l.transformer.text_projection.weight']
loaded straight to GPU
Requested to load SDXL
Loading 1 new model
Cache lookup: Key='2a7f8ef5-49f3-4eba-b608-ae7acbb2e7c6', Cached Model Type='<class 'comfy.model_base.SDXL'>'
Cache lookup: Key='1bc2cd79-33f5-45fe-9421-46d892f695f6', Cached Model Type='<class 'NoneType'>'
!!! Exception during processing !!!
Traceback (most recent call last):
  File "/app/ComfyUI/execution.py", line 151, in recursive_execute
    output_data, output_ui = get_output_data(obj, input_data_all)
  File "/app/ComfyUI/execution.py", line 81, in get_output_data
    return_values = map_node_over_list(obj, input_data_all, obj.FUNCTION, allow_interrupt=True)
  File "/app/ComfyUI/execution.py", line 74, in map_node_over_list
    results.append(getattr(obj, func)(**slice_dict(input_data_all, i)))
  File "/root/miniconda3/envs/venv_image/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/app/ComfyUI/custom_nodes/onediff_comfy_nodes/_nodes.py", line 253, in onediff_load_checkpoint
    vae = self.speedup(
  File "/root/miniconda3/envs/venv_image/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/app/ComfyUI/custom_nodes/onediff_comfy_nodes/_nodes.py", line 80, in speedup
    return (booster(model, *args, **kwargs),)
  File "/app/ComfyUI/custom_nodes/onediff_comfy_nodes/modules/booster_scheduler.py", line 61, in __call__
    return self.compile(model=model, ckpt_name=ckpt_name, **kwargs)
  File "/app/ComfyUI/custom_nodes/onediff_comfy_nodes/modules/booster_scheduler.py", line 24, in wrapper
    self.cache_service.put(cached_model_key, cached_model)
  File "/app/ComfyUI/custom_nodes/onediff_comfy_nodes/modules/booster_cache.py", line 71, in put
    cached_model = get_cached_model(model)
  File "/root/miniconda3/envs/venv_image/lib/python3.10/functools.py", line 889, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
  File "/app/ComfyUI/custom_nodes/onediff_comfy_nodes/modules/booster_cache.py", line 54, in _
    if is_oneflow_available() and not is_disable_oneflow_backend():
NameError: name 'is_oneflow_available' is not defined
```