### PR TITLE
support diffusers v0.29

### DIFF
--- a/src/infer_compiler_registry/register_diffusers/transformer_2d/v_0_28.py
+++ b/src/infer_compiler_registry/register_diffusers/transformer_2d/v_0_28.py
@@ -1,0 +1,287 @@
+import torch
+from typing import Optional, Dict, Any
+from onediff.infer_compiler.backends.oneflow.transform import transform_mgr
+transformed_diffusers = transform_mgr.transform_package("diffusers")
+ConfigMixin = transformed_diffusers.configuration_utils.ConfigMixin
+register_to_config = transformed_diffusers.configuration_utils.register_to_config
+ImagePositionalEmbeddings = (
+    transformed_diffusers.models.embeddings.ImagePositionalEmbeddings
+)
+USE_PEFT_BACKEND = transformed_diffusers.utils.USE_PEFT_BACKEND
+BaseOutput = transformed_diffusers.utils.BaseOutput
+deprecate = transformed_diffusers.utils.deprecate
+is_torch_version = transformed_diffusers.utils.is_torch_version
+BasicTransformerBlock = transformed_diffusers.models.attention.BasicTransformerBlock
+PatchEmbed = transformed_diffusers.models.embeddings.PatchEmbed
+PixArtAlphaTextProjection = (
+    transformed_diffusers.models.embeddings.PixArtAlphaTextProjection
+)
+LoRACompatibleConv = transformed_diffusers.models.lora.LoRACompatibleConv
+LoRACompatibleLinear = transformed_diffusers.models.lora.LoRACompatibleLinear
+ModelMixin = transformed_diffusers.models.modeling_utils.ModelMixin
+AdaLayerNormSingle = transformed_diffusers.models.normalization.AdaLayerNormSingle
+Transformer2DModelOutput = transformed_diffusers.models.transformers.transformer_2d.Transformer2DModelOutput
+proxy_Transformer2DModel = (
+    transformed_diffusers.models.transformers.transformer_2d.Transformer2DModel
+)
+
+class Transformer2DModel(proxy_Transformer2DModel):
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        encoder_hidden_states: Optional[torch.Tensor] = None,
+        timestep: Optional[torch.LongTensor] = None,
+        added_cond_kwargs: Dict[str, torch.Tensor] = None,
+        class_labels: Optional[torch.LongTensor] = None,
+        cross_attention_kwargs: Dict[str, Any] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        encoder_attention_mask: Optional[torch.Tensor] = None,
+        return_dict: bool = True,
+    ):
+        # import ipdb; ipdb.set_trace()
+        """
+        The [`Transformer2DModel`] forward method.
+
+        Args:
+            hidden_states (`torch.LongTensor` of shape `(batch size, num latent pixels)` if discrete, `torch.Tensor` of shape `(batch size, channel, height, width)` if continuous):
+                Input `hidden_states`.
+            encoder_hidden_states ( `torch.Tensor` of shape `(batch size, sequence len, embed dims)`, *optional*):
+                Conditional embeddings for cross attention layer. If not given, cross-attention defaults to
+                self-attention.
+            timestep ( `torch.LongTensor`, *optional*):
+                Used to indicate denoising step. Optional timestep to be applied as an embedding in `AdaLayerNorm`.
+            class_labels ( `torch.LongTensor` of shape `(batch size, num classes)`, *optional*):
+                Used to indicate class labels conditioning. Optional class labels to be applied as an embedding in
+                `AdaLayerZeroNorm`.
+            cross_attention_kwargs ( `Dict[str, Any]`, *optional*):
+                A kwargs dictionary that if specified is passed along to the `AttentionProcessor` as defined under
+                `self.processor` in
+                [diffusers.models.attention_processor](https://github.com/huggingface/diffusers/blob/main/src/diffusers/models/attention_processor.py).
+            attention_mask ( `torch.Tensor`, *optional*):
+                An attention mask of shape `(batch, key_tokens)` is applied to `encoder_hidden_states`. If `1` the mask
+                is kept, otherwise if `0` it is discarded. Mask will be converted into a bias, which adds large
+                negative values to the attention scores corresponding to "discard" tokens.
+            encoder_attention_mask ( `torch.Tensor`, *optional*):
+                Cross-attention mask applied to `encoder_hidden_states`. Two formats supported:
+
+                    * Mask `(batch, sequence_length)` True = keep, False = discard.
+                    * Bias `(batch, 1, sequence_length)` 0 = keep, -10000 = discard.
+
+                If `ndim == 2`: will be interpreted as a mask, then converted into a bias consistent with the format
+                above. This bias will be added to the cross-attention scores.
+            return_dict (`bool`, *optional*, defaults to `True`):
+                Whether or not to return a [`~models.unets.unet_2d_condition.UNet2DConditionOutput`] instead of a plain
+                tuple.
+
+        Returns:
+            If `return_dict` is True, an [`~models.transformers.transformer_2d.Transformer2DModelOutput`] is returned,
+            otherwise a `tuple` where the first element is the sample tensor.
+        """
+        if cross_attention_kwargs is not None:
+            if cross_attention_kwargs.get("scale", None) is not None:
+                logger.warning("Passing `scale` to `cross_attention_kwargs` is deprecated. `scale` will be ignored.")
+        # ensure attention_mask is a bias, and give it a singleton query_tokens dimension.
+        #   we may have done this conversion already, e.g. if we came here via UNet2DConditionModel#forward.
+        #   we can tell by counting dims; if ndim == 2: it's a mask rather than a bias.
+        # expects mask of shape:
+        #   [batch, key_tokens]
+        # adds singleton query_tokens dimension:
+        #   [batch,                    1, key_tokens]
+        # this helps to broadcast it as a bias over attention scores, which will be in one of the following shapes:
+        #   [batch,  heads, query_tokens, key_tokens] (e.g. torch sdp attn)
+        #   [batch * heads, query_tokens, key_tokens] (e.g. xformers or classic attn)
+        if attention_mask is not None and attention_mask.ndim == 2:
+            # assume that mask is expressed as:
+            #   (1 = keep,      0 = discard)
+            # convert mask into a bias that can be added to attention scores:
+            #       (keep = +0,     discard = -10000.0)
+            attention_mask = (1 - attention_mask.to(hidden_states.dtype)) * -10000.0
+            attention_mask = attention_mask.unsqueeze(1)
+
+        # convert encoder_attention_mask to a bias the same way we do for attention_mask
+        if encoder_attention_mask is not None and encoder_attention_mask.ndim == 2:
+            encoder_attention_mask = (1 - encoder_attention_mask.to(hidden_states.dtype)) * -10000.0
+            encoder_attention_mask = encoder_attention_mask.unsqueeze(1)
+
+        hidden_states_in = hidden_states
+
+        # 1. Input
+        if self.is_input_continuous:
+            batch_size, _, height, width = hidden_states.shape
+            residual = hidden_states
+            hidden_states, inner_dim = self._operate_on_continuous_inputs(hidden_states)
+        elif self.is_input_vectorized:
+            hidden_states = self.latent_image_embedding(hidden_states)
+        elif self.is_input_patches:
+            height, width = hidden_states.shape[-2] // self.patch_size, hidden_states.shape[-1] // self.patch_size
+            hidden_states, encoder_hidden_states, timestep, embedded_timestep = self._operate_on_patched_inputs(
+                hidden_states, encoder_hidden_states, timestep, added_cond_kwargs
+            )
+
+        # 2. Blocks
+        for block in self.transformer_blocks:
+            if self.training and self.gradient_checkpointing:
+
+                def create_custom_forward(module, return_dict=None):
+                    def custom_forward(*inputs):
+                        if return_dict is not None:
+                            return module(*inputs, return_dict=return_dict)
+                        else:
+                            return module(*inputs)
+
+                    return custom_forward
+
+                ckpt_kwargs: Dict[str, Any] = {"use_reentrant": False} if is_torch_version(">=", "1.11.0") else {}
+                hidden_states = torch.utils.checkpoint.checkpoint(
+                    create_custom_forward(block),
+                    hidden_states,
+                    attention_mask,
+                    encoder_hidden_states,
+                    encoder_attention_mask,
+                    timestep,
+                    cross_attention_kwargs,
+                    class_labels,
+                    **ckpt_kwargs,
+                )
+            else:
+                hidden_states = block(
+                    hidden_states,
+                    attention_mask=attention_mask,
+                    encoder_hidden_states=encoder_hidden_states,
+                    encoder_attention_mask=encoder_attention_mask,
+                    timestep=timestep,
+                    cross_attention_kwargs=cross_attention_kwargs,
+                    class_labels=class_labels,
+                )
+
+        # 3. Output
+        if self.is_input_continuous:
+            if not self.use_linear_projection:
+                hidden_states = (
+                    hidden_states.permute(0, 2, 1)
+                    .reshape_as(hidden_states_in)
+                    .contiguous()
+                )
+                # hidden_states = (
+                #     hidden_states.reshape(batch_size, height, width, inner_dim).permute(0, 3, 1, 2).contiguous()
+                # )
+                hidden_states = self.proj_out(hidden_states)
+            else:
+                hidden_states = self.proj_out(hidden_states)
+                hidden_states = (
+                    hidden_states.permute(0, 2, 1)
+                    .reshape_as(hidden_states_in)
+                    .contiguous()
+                )
+                # hidden_states = (
+                #     hidden_states.reshape(batch_size, height, width, inner_dim).permute(0, 3, 1, 2).contiguous()
+                # )
+
+            output = hidden_states + residual
+            # output = self._get_output_for_continuous_inputs(
+            #     hidden_states=hidden_states,
+            #     residual=residual,
+            #     batch_size=batch_size,
+            #     height=height,
+            #     width=width,
+            #     inner_dim=inner_dim,
+            # )
+        elif self.is_input_vectorized:
+            output = self._get_output_for_vectorized_inputs(hidden_states)
+        elif self.is_input_patches:
+            output = self._get_output_for_patched_inputs(
+                hidden_states=hidden_states,
+                timestep=timestep,
+                class_labels=class_labels,
+                embedded_timestep=embedded_timestep,
+                height=height,
+                width=width,
+            )
+
+        if not return_dict:
+            return (output,)
+
+        return Transformer2DModelOutput(sample=output)
+
+    def _get_output_for_continuous_inputs(self, hidden_states, residual, batch_size, height, width, inner_dim):
+        # # hidden_states = hidden_states.reshape(batch, height, width, inner_dim).permute(0, 3, 1, 2).contiguous()
+        # hidden_states = (
+        #     hidden_states.permute(0, 2, 1)
+        #     .reshape_as(hidden_states_in)
+        #     .contiguous()
+        # )
+        # hidden_states = self.proj_out(hidden_states)
+        # import ipdb; ipdb.set_trace()
+        return
+        if not self.use_linear_projection:
+            hidden_states = (
+                hidden_states.reshape(batch_size, height, width, inner_dim).permute(0, 3, 1, 2).contiguous()
+            )
+            hidden_states = self.proj_out(hidden_states)
+        else:
+            hidden_states = self.proj_out(hidden_states)
+            hidden_states = (
+                hidden_states.reshape(batch_size, height, width, inner_dim).permute(0, 3, 1, 2).contiguous()
+            )
+
+        output = hidden_states + residual
+        return output
+
+    def _get_output_for_vectorized_inputs(self, hidden_states):
+        raise
+        hidden_states = self.norm_out(hidden_states)
+        logits = self.out(hidden_states)
+        # (batch, self.num_vector_embeds - 1, self.num_latent_pixels)
+        logits = logits.permute(0, 2, 1)
+        # log(p(x_0))
+        output = F.log_softmax(logits.double(), dim=1).float()
+        return output
+
+    def _get_output_for_patched_inputs(
+        self, hidden_states, timestep, class_labels, embedded_timestep, height=None, width=None
+    ):
+        raise
+        # import ipdb; ipdb.set_trace()
+        if self.config.norm_type != "ada_norm_single":
+            conditioning = self.transformer_blocks[0].norm1.emb(
+                timestep, class_labels, hidden_dtype=hidden_states.dtype
+            )
+            shift, scale = self.proj_out_1(F.silu(conditioning)).chunk(2, dim=1)
+            hidden_states = self.norm_out(hidden_states) * (1 + scale[:, None]) + shift[:, None]
+            hidden_states = self.proj_out_2(hidden_states)
+        elif self.config.norm_type == "ada_norm_single":
+            shift, scale = (self.scale_shift_table[None] + embedded_timestep[:, None]).chunk(2, dim=1)
+            hidden_states = self.norm_out(hidden_states)
+            # Modulation
+            hidden_states = hidden_states * (1 + scale) + shift
+            hidden_states = self.proj_out(hidden_states)
+            hidden_states = hidden_states.squeeze(1)
+
+        # unpatchify
+        if self.adaln_single is None:
+            height = width = int(hidden_states.shape[1] ** 0.5)
+        hidden_states = hidden_states.reshape(
+            shape=(-1, height, width, self.patch_size, self.patch_size, self.out_channels)
+        )
+        hidden_states = torch.einsum("nhwpqc->nchpwq", hidden_states)
+        output = hidden_states.reshape(
+            shape=(-1, self.out_channels, height * self.patch_size, width * self.patch_size)
+        )
+        return output
+
+    def _operate_on_continuous_inputs(self, hidden_states):
+        batch, _, height, width = hidden_states.shape
+        hidden_states = self.norm(hidden_states)
+
+        if not self.use_linear_projection:
+            hidden_states = self.proj_in(hidden_states)
+            inner_dim = hidden_states.shape[1]
+            # hidden_states = hidden_states.permute(0, 2, 3, 1).reshape(batch, height * width, inner_dim)
+            hidden_states = hidden_states.permute(0, 2, 3, 1).flatten(1, 2)
+        else:
+            inner_dim = hidden_states.shape[1]
+            # hidden_states = hidden_states.permute(0, 2, 3, 1).reshape(batch, height * width, inner_dim)
+            hidden_states = hidden_states.permute(0, 2, 3, 1).flatten(1, 2)
+            hidden_states = self.proj_in(hidden_states)
+
+        return hidden_states, inner_dim

--- a/src/infer_compiler_registry/register_diffusers/transformer_2d_oflow.py
+++ b/src/infer_compiler_registry/register_diffusers/transformer_2d_oflow.py
@@ -13,6 +13,7 @@ transformed_diffusers = transform_mgr.transform_package("diffusers")
 diffusers_0220_v = version.parse("0.22.0")
 diffusers_02499_v = version.parse("0.24.99")
 diffusers_0270_v = version.parse("0.27.0")
+diffusers_0280_v = version.parse("0.28.0")
 diffusers_version = version.parse(importlib.metadata.version("diffusers"))
 
 if diffusers_version < diffusers_0220_v:
@@ -885,7 +886,7 @@ elif diffusers_version < diffusers_02499_v:
 
             return Transformer2DModelOutput(sample=output)
 
-else:
+elif diffusers_version < diffusers_0280_v:
     transformed_diffusers = transform_mgr.transform_package("diffusers")
     ConfigMixin = transformed_diffusers.configuration_utils.ConfigMixin
     register_to_config = transformed_diffusers.configuration_utils.register_to_config
@@ -1196,3 +1197,5 @@ else:
                 return (output,)
 
             return Transformer2DModelOutput(sample=output)
+else:
+    from .transformer_2d.v_0_28 import Transformer2DModel, Transformer2DModelOutput

--- a/src/infer_compiler_registry/register_diffusers/unet_2d_blocks_oflow.py
+++ b/src/infer_compiler_registry/register_diffusers/unet_2d_blocks_oflow.py
@@ -10,9 +10,14 @@ diffusers_version = version.parse(importlib.metadata.version("diffusers"))
 
 transformed_diffusers = transform_mgr.transform_package("diffusers")
 
+if diffusers_version >= version.parse("0.26.0"):
+    diffusers_unet_2d_blocks = transformed_diffusers.models.unets.unet_2d_blocks
+else:
+    diffusers_unet_2d_blocks = transformed_diffusers.models.unet_2d_blocks
+
 if diffusers_version < diffusers_0210_v:
 
-    class AttnUpBlock2D(transformed_diffusers.models.unet_2d_blocks.AttnUpBlock2D):
+    class AttnUpBlock2D(diffusers_unet_2d_blocks.AttnUpBlock2D):
         def forward(
             self,
             hidden_states,
@@ -38,7 +43,7 @@ if diffusers_version < diffusers_0210_v:
                         hidden_states = upsampler(hidden_states)
 
     class CrossAttnUpBlock2D(
-        transformed_diffusers.models.unet_2d_blocks.CrossAttnUpBlock2D
+        diffusers_unet_2d_blocks.CrossAttnUpBlock2D
     ):
         def forward(
             self,
@@ -105,7 +110,7 @@ if diffusers_version < diffusers_0210_v:
 
             return hidden_states
 
-    class UpBlock2D(transformed_diffusers.models.unet_2d_blocks.UpBlock2D):
+    class UpBlock2D(diffusers_unet_2d_blocks.UpBlock2D):
         def forward(
             self,
             hidden_states,
@@ -150,7 +155,7 @@ if diffusers_version < diffusers_0210_v:
 
 else:
 
-    class AttnUpBlock2D(transformed_diffusers.models.unet_2d_blocks.AttnUpBlock2D):
+    class AttnUpBlock2D(diffusers_unet_2d_blocks.AttnUpBlock2D):
         def forward(
             self,
             hidden_states: torch.FloatTensor,
@@ -180,7 +185,7 @@ else:
             return hidden_states
 
     class CrossAttnUpBlock2D(
-        transformed_diffusers.models.unet_2d_blocks.CrossAttnUpBlock2D
+        diffusers_unet_2d_blocks.CrossAttnUpBlock2D
     ):
         def forward(
             self,
@@ -277,7 +282,7 @@ else:
 
             return hidden_states
 
-    class UpBlock2D(transformed_diffusers.models.unet_2d_blocks.UpBlock2D):
+    class UpBlock2D(diffusers_unet_2d_blocks.UpBlock2D):
         def forward(
             self,
             hidden_states: torch.FloatTensor,

--- a/src/infer_compiler_registry/register_diffusers/unet_2d_condition_oflow.py
+++ b/src/infer_compiler_registry/register_diffusers/unet_2d_condition_oflow.py
@@ -6,12 +6,20 @@ from onediff.infer_compiler.backends.oneflow.transform import transform_mgr
 from packaging import version
 
 diffusers_0210_v = version.parse("0.21.0")
+diffusers_0260_v = version.parse("0.26.0")
 diffusers_version = version.parse(importlib.metadata.version("diffusers"))
 
 transformed_diffusers = transform_mgr.transform_package("diffusers")
-UNet2DConditionOutput = (
-    transformed_diffusers.models.unet_2d_condition.UNet2DConditionOutput
-)
+if diffusers_version < diffusers_0260_v:
+    UNet2DConditionOutput = (
+        transformed_diffusers.models.unet_2d_condition.UNet2DConditionOutput
+    )
+    proxy_UNet2DConditionModel = transformed_diffusers.models.unet_2d_condition.UNet2DConditionModel
+else:
+    UNet2DConditionOutput = (
+        transformed_diffusers.models.unets.unet_2d_condition.UNet2DConditionOutput
+    )
+    proxy_UNet2DConditionModel = transformed_diffusers.models.unets.unet_2d_condition.UNet2DConditionModel
 
 try:
     USE_PEFT_BACKEND = transformed_diffusers.utils.USE_PEFT_BACKEND
@@ -21,9 +29,7 @@ except Exception as e:
     USE_PEFT_BACKEND = False
 
 
-class UNet2DConditionModel(
-    transformed_diffusers.models.unet_2d_condition.UNet2DConditionModel
-):
+class UNet2DConditionModel(proxy_UNet2DConditionModel):
     def forward(
         self,
         sample: torch.FloatTensor,

--- a/src/onediff/infer_compiler/backends/oneflow/args_tree_util.py
+++ b/src/onediff/infer_compiler/backends/oneflow/args_tree_util.py
@@ -1,5 +1,6 @@
 import torch
 import oneflow as flow  # usort: skip
+import functools
 from oneflow.framework.args_tree import ArgsTree
 
 from onediff.utils import logger
@@ -35,6 +36,7 @@ def input_output_processor(func):
         out = out_tree.map_leaf(output_fn)
         return out[0]
 
+    @functools.wraps(func)
     def wrapper(self: "OneflowDeployableModule", *args, **kwargs):
         mapped_args, mapped_kwargs, input_structure_key = process_input(*args, **kwargs)
         if (

--- a/src/onediff/infer_compiler/backends/oneflow/import_tools/patch_for_compiler.py
+++ b/src/onediff/infer_compiler/backends/oneflow/import_tools/patch_for_compiler.py
@@ -16,9 +16,9 @@ class FakeCuda:
 
     @staticmethod
     def _scaled_dot_product_attention_math(
-        query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False
+        query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None,
     ):
-        d_k = query.size(-1)
+        scale_factor = 1 / math.sqrt(query.size(-1)) if scale is None else scale
 
         if is_causal:
             assert attn_mask is None, "Cannot use both attn_mask and is_causal=True"
@@ -34,7 +34,7 @@ class FakeCuda:
                 new_attn_mask.masked_fill_(mask, float("-inf"))
                 attn_mask = new_attn_mask
 
-        scores = flow.matmul(query, key.transpose(-2, -1)) / math.sqrt(d_k)
+        scores = flow.matmul(query, key.transpose(-2, -1)) / scale_factor
 
         if attn_mask is not None:
             scores.add_(attn_mask)
@@ -51,7 +51,7 @@ class FakeCuda:
 
     @staticmethod
     def scaled_dot_product_attention(
-        query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False
+        query, key, value, attn_mask=None, dropout_p=0.0, is_causal=False, scale=None,
     ):
         """Scaled Dot-Product Attention
         Args:
@@ -77,7 +77,7 @@ class FakeCuda:
         """
         if attn_mask is not None or dropout_p > 0.0:
             return FakeCuda._scaled_dot_product_attention_math(
-                query, key, value, attn_mask, dropout_p, is_causal
+                query, key, value, attn_mask, dropout_p, is_causal, scale
             )
 
         batch_size, num_heads, target_seq_len, head_dim = query.shape
@@ -91,6 +91,7 @@ class FakeCuda:
             value_layout="BHMK",
             output_layout="BM(HK)",
             causal=is_causal,
+            scale=scale,
         )
         # (N, L, H x Ev) -> (N, H, L, Ev)
         value_embed_dim = value.shape[-1]

--- a/src/onediff/infer_compiler/backends/oneflow/online_quantization_utils.py
+++ b/src/onediff/infer_compiler/backends/oneflow/online_quantization_utils.py
@@ -1,3 +1,5 @@
+import functools
+
 def patch_input_adapter(in_args, in_kwargs):
     return in_args, in_kwargs
 
@@ -45,6 +47,7 @@ def online_quantize_model(
 
 
 def quantize_and_deploy_wrapper(func):
+    @functools.wraps(func)
     def wrapper(self: "DeployableModule", *args, **kwargs):
         torch_model = self._torch_module
         quant_config = self._deployable_module_quant_config


### PR DESCRIPTION
社区用户反馈 0.29 diffusers 切换分辨率报错 https://github.com/siliconflow/onediff/issues/1033
原因是 0.29 的 transformer2d 的实现从 diffusers.models.transformer_2d 挪到了 diffusers.models.transformers.transformer_2d 里面，导致原来的代码 register 转换的 map 失败，运行报错

这个 PR 修复了 bug，把 0.29 的对应实现放在了一个新的文件里，增加可读性，并且准备以此为例子，对这部分代码进行重构。
另外对于装饰器函数，增加了 wrap(func) 的装饰。（原来的实现会改变函数 inspect 的内容，导致很难 debug）