### PR TITLE
Add nexfort cache graph in readme

### DIFF
--- a/onediff_comfy_nodes/README.md
+++ b/onediff_comfy_nodes/README.md
@@ -132,8 +132,8 @@ The "Load Checkpoint - OneDiff" node  set `vae_speedup` :  `enable` to enable VA
 # Set custom directory for saving graphs in ComfyUI with OneFlow backend
 export COMFYUI_ONEDIFF_SAVE_GRAPH_DIR="/path/to/save/graphs"
 
-# Enable graph cache for faster compilation
-export TORCHINDUCTOR_FX_GRAPH_CACHE=1
+# Enable graph cache to avoid recompiling
+export NEXFORT_GRAPH_CACHE=1
 
 # Specify persistent cache directory for Torchinductor
 export TORCHINDUCTOR_CACHE_DIR=~/.torchinductor_cache

--- a/onediff_comfy_nodes/docs/sd3/README.md
+++ b/onediff_comfy_nodes/docs/sd3/README.md
@@ -77,8 +77,8 @@ https://huggingface.co/stabilityai/stable-diffusion-3-medium/resolve/main/text_e
 # https://github.com/huggingface/transformers/issues/5486
 export TOKENIZERS_PARALLELISM=false
 
-# For graph cache to speedup compilation
-export TORCHINDUCTOR_FX_GRAPH_CACHE=1
+# For graph cache to to avoid recompiling
+export NEXFORT_GRAPH_CACHE=1
 # For persistent cache dir
 export TORCHINDUCTOR_CACHE_DIR=~/.torchinductor_cache
 cd $COMFYUI_DIR && python main.py --gpu-only --disable-cuda-malloc

--- a/src/onediff/infer_compiler/README.md
+++ b/src/onediff/infer_compiler/README.md
@@ -71,7 +71,7 @@ Details at: https://github.com/siliconflow/onediff/tree/main/onediff_diffusers_e
 
 Setting cache:
 ```
-# Enabled Cache Nexfort Graph. Default Off
+# Enabled Cache Compiled Graph. Default Off
 export NEXFORT_GRAPH_CACHE=1
 
 # Setting Inductor - Autotuning Cache DIR. This cache is enabled by default.

--- a/src/onediff/infer_compiler/README.md
+++ b/src/onediff/infer_compiler/README.md
@@ -71,8 +71,8 @@ Details at: https://github.com/siliconflow/onediff/tree/main/onediff_diffusers_e
 
 Setting cache:
 ```
-# Enabled Inductor - FX Graph Cache. Default Off
-export TORCHINDUCTOR_FX_GRAPH_CACHE=1
+# Enabled Cache Nexfort Graph. Default Off
+export NEXFORT_GRAPH_CACHE=1
 
 # Setting Inductor - Autotuning Cache DIR. This cache is enabled by default.
 export TORCHINDUCTOR_CACHE_DIR=~/torchinductor

--- a/src/onediff/infer_compiler/backends/nexfort/README.md
+++ b/src/onediff/infer_compiler/backends/nexfort/README.md
@@ -27,8 +27,8 @@ Details at: https://github.com/siliconflow/onediff/tree/main/onediff_diffusers_e
 
 Setting cache:
 ```
-# Enabled Inductor - FX Graph Cache. Default Off
-export TORCHINDUCTOR_FX_GRAPH_CACHE=1
+# Enabled Cache Nexfort Graph Cache. Default Off
+export NEXFORT_GRAPH_CACHE=1
 
 # Setting Inductor - Autotuning Cache DIR. This cache is enabled by default.
 export TORCHINDUCTOR_CACHE_DIR=~/.torchinductor

--- a/src/onediff/infer_compiler/backends/nexfort/README.md
+++ b/src/onediff/infer_compiler/backends/nexfort/README.md
@@ -27,7 +27,7 @@ Details at: https://github.com/siliconflow/onediff/tree/main/onediff_diffusers_e
 
 Setting cache:
 ```
-# Enabled Cache Nexfort Graph Cache. Default Off
+# Enabled Cache Compiled Graph Cache. Default Off
 export NEXFORT_GRAPH_CACHE=1
 
 # Setting Inductor - Autotuning Cache DIR. This cache is enabled by default.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated environment variable for caching from `TORCHINDUCTOR_FX_GRAPH_CACHE` to `NEXFORT_GRAPH_CACHE` across documentation.
  - Clarified purpose of the caching variable to emphasize avoiding recompilation.
  
- **Documentation**
  - Revised README files to reflect changes in caching variable and updated instructions for user configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->