### PR TITLE
enterprise edition to enterprise solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,11 +261,12 @@ If you want to do distributed inference, you can use onediff's compiler to do si
 
 ### onediff Enterprise Solution
 If you need Enterprise-level Support for your system or business, you can email us at contact@siliconflow.com, or contact us through the website: https://siliconflow.cn/pricing
-|                                                      | onediff Enterprise Solution                      |
-| ---------------------------------------------------- | ------------------------------------------------ |
-| Diffusion model with more Extreme optimization       | Usually another 20%~30% or more performance gain |
-| Workflow end-to-end speedup and deployment solutions | Sometimes 200%~300% performance gain             |
-| Technical Support for deployment                     | High priority support                            |
+|                                                          | onediff Enterprise Solution                      |
+| -------------------------------------------------------- | ------------------------------------------------ |
+| More extreme compiler optimization for diffusion process | Usually another 20%~30% or more performance gain |
+| Workflow end-to-end speedup solutions                    | Sometimes 200%~300% performance gain             |
+| Workflow end-to-end deployment solutions                 | Workflow to online model API                     |
+| Technical Support for deployment                         | High priority support                            |
 
 ## Citation
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -264,8 +264,8 @@ If you need Enterprise-level Support for your system or business, you can email 
 |                                                          | onediff Enterprise Solution                      |
 | -------------------------------------------------------- | ------------------------------------------------ |
 | More extreme compiler optimization for diffusion process | Usually another 20%~30% or more performance gain |
-| Workflow end-to-end speedup solutions                    | Sometimes 200%~300% performance gain             |
-| Workflow end-to-end deployment solutions                 | Workflow to online model API                     |
+| End-to-end workflow speedup solutions                    | Sometimes 200%~300% performance gain             |
+| End-to-end workflow deployment solutions                 | Workflow to online model API                     |
 | Technical Support for deployment                         | High priority support                            |
 
 ## Citation

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ If you have contributed significantly to open-source software and are interested
     + [PyTorch Module compilation](#pytorch-module-compilation)
     + [Avoid compilation time for new input shape](#avoid-compilation-time-for-new-input-shape)
     + [Avoid compilation time for online serving](#avoid-compilation-time-for-online-serving)
-  * [Distributed Run](#distributed-run)
+    + [Distributed Run](#distributed-run)
   * [onediff Enterprise Solution](#onediff-enterprise-solution)
 <!-- tocstop -->
 
@@ -256,10 +256,8 @@ onediff supports the acceleration for SOTA models.
 Compile and save the compiled result offline, then load it online for serving
 - [Save and Load the compiled graph](https://github.com/siliconflow/onediff/blob/main/onediff_diffusers_extensions/examples/text_to_image_sdxl_save_load.py)
 - Compile at one device(such as device 0), then use the compiled result to other device(such as device 1~7). [Change device of the compiled graph to do multi-process serving](https://github.com/siliconflow/onediff/blob/main/onediff_diffusers_extensions/examples/text_to_image_sdxl_mp_load.py)
-
-### Distributed Run
-If you want to do distributed inference, you can use onediff's compiler to do single-device acceleration in a distributed inference engine such as:
-- [xDiT](https://github.com/xdit-project/xDiT)
+#### Distributed Run
+If you want to do distributed inference, you can use onediff's compiler to do single-device acceleration in a distributed inference engine such as [xDiT](https://github.com/xdit-project/xDiT)
 
 ### onediff Enterprise Solution
 If you need Enterprise-level Support for your system or business, you can email us at contact@siliconflow.com, or contact us through the website: https://siliconflow.cn/pricing

--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ If you have contributed significantly to open-source software and are interested
     + [PyTorch Module compilation](#pytorch-module-compilation)
     + [Avoid compilation time for new input shape](#avoid-compilation-time-for-new-input-shape)
     + [Avoid compilation time for online serving](#avoid-compilation-time-for-online-serving)
-    + [onediff Enterprise Edition](#onediff-enterprise-edition)
   * [Distributed Run](#distributed-run)
+  * [onediff Enterprise Solution](#onediff-enterprise-solution)
 <!-- tocstop -->
 
 ## Documentation
@@ -256,17 +256,18 @@ onediff supports the acceleration for SOTA models.
 Compile and save the compiled result offline, then load it online for serving
 - [Save and Load the compiled graph](https://github.com/siliconflow/onediff/blob/main/onediff_diffusers_extensions/examples/text_to_image_sdxl_save_load.py)
 - Compile at one device(such as device 0), then use the compiled result to other device(such as device 1~7). [Change device of the compiled graph to do multi-process serving](https://github.com/siliconflow/onediff/blob/main/onediff_diffusers_extensions/examples/text_to_image_sdxl_mp_load.py)
-#### onediff Enterprise Edition
-If you need Enterprise-level Support for your system or business, you can email us at contact@siliconflow.com, or contact us through the website: https://siliconflow.cn/pricing
-
-|                                                                                                           | onediff Enterprise Edition              | onediff Community Edition               |
-| --------------------------------------------------------------------------------------------------------- | --------------------------------------- | --------------------------------------- |
-| More Extreme and Dedicated optimization(usually another 20~100% performance gain) for the most used model | Yes                                     |                                         |
-| Technical Support for deployment                                                                          | High priority support                   | Community                               |
 
 ### Distributed Run
 If you want to do distributed inference, you can use onediff's compiler to do single-device acceleration in a distributed inference engine such as:
 - [xDiT](https://github.com/xdit-project/xDiT)
+
+### onediff Enterprise Solution
+If you need Enterprise-level Support for your system or business, you can email us at contact@siliconflow.com, or contact us through the website: https://siliconflow.cn/pricing
+|                                                      | onediff Enterprise Solution                      |
+| ---------------------------------------------------- | ------------------------------------------------ |
+| Diffusion model with more Extreme optimization       | Usually another 20%~30% or more performance gain |
+| Workflow end-to-end speedup and deployment solutions | Sometimes 200%~300% performance gain             |
+| Technical Support for deployment                     | High priority support                            |
 
 ## Citation
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ If you want to do distributed inference, you can use onediff's compiler to do si
 
 ### OneDiff Enterprise Solution
 If you need Enterprise-level Support for your system or business, you can email us at contact@siliconflow.com, or contact us through the website: https://siliconflow.cn/pricing
-|                                                          | onediff Enterprise Solution                      |
+|                                                          | Onediff Enterprise Solution                      |
 | -------------------------------------------------------- | ------------------------------------------------ |
 | More extreme compiler optimization for diffusion process | Usually another 20%~30% or more performance gain |
 | End-to-end workflow speedup solutions                    | Sometimes 200%~300% performance gain             |

--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ If you need Enterprise-level Support for your system or business, you can email 
 | More extreme compiler optimization for diffusion process | Usually another 20%~30% or more performance gain |
 | End-to-end workflow speedup solutions                    | Sometimes 200%~300% performance gain             |
 | End-to-end workflow deployment solutions                 | Workflow to online model API                     |
-| Technical Support for deployment                         | High priority support                            |
+| Technical support for deployment                         | High priority support                            |
 
 ## Citation
 ```bibtex

--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Compile and save the compiled result offline, then load it online for serving
 #### Distributed Run
 If you want to do distributed inference, you can use onediff's compiler to do single-device acceleration in a distributed inference engine such as [xDiT](https://github.com/xdit-project/xDiT)
 
-### onediff Enterprise Solution
+### OneDiff Enterprise Solution
 If you need Enterprise-level Support for your system or business, you can email us at contact@siliconflow.com, or contact us through the website: https://siliconflow.cn/pricing
 |                                                          | onediff Enterprise Solution                      |
 | -------------------------------------------------------- | ------------------------------------------------ |

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ If you have contributed significantly to open-source software and are interested
     + [Avoid compilation time for new input shape](#avoid-compilation-time-for-new-input-shape)
     + [Avoid compilation time for online serving](#avoid-compilation-time-for-online-serving)
     + [Distributed Run](#distributed-run)
-  * [onediff Enterprise Solution](#onediff-enterprise-solution)
+  * [OneDiff Enterprise Solution](#onediff-enterprise-solution)
 <!-- tocstop -->
 
 ## Documentation


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Renamed "onediff Enterprise Edition" to "onediff Enterprise Solution" for clarity on offerings.
	- Enhanced details on performance gains and support options within the "onediff Enterprise Solution" section.
	- Elevated the "Distributed Run" section to a prominent header, emphasizing distributed inference capabilities.
	- Adjusted content in the "Distributed Run" section to highlight the use of onediff's compiler in distributed inference engines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->