### PR TITLE
Fix diffusers attention register

### DIFF
--- a/onediff_diffusers_extensions/examples/text_to_image_sdxl_enterprise.py
+++ b/onediff_diffusers_extensions/examples/text_to_image_sdxl_enterprise.py
@@ -83,7 +83,6 @@ pipe = StableDiffusionXLPipeline.from_pretrained(
     args.model,
     torch_dtype=torch.float16,
     use_safetensors=True,
-    variant="fp16",
 )
 pipe.to("cuda")
 

--- a/src/infer_compiler_registry/register_diffusers/attention_processor_oflow.py
+++ b/src/infer_compiler_registry/register_diffusers/attention_processor_oflow.py
@@ -361,6 +361,16 @@ class Attention(nn.Module):
         # here we simply pass along all tensors to the selected processor class
         # For standard processors that are defined here, `**cross_attention_kwargs` is empty
 
+        from diffusers.models.attention_processor import (
+            AttnProcessor as DiffusersAttnProcessor,
+            AttnProcessor2_0 as DiffusersAttnProcessor2_0,
+        )
+
+        if isinstance(self.processor, DiffusersAttnProcessor) or isinstance(
+            self.processor, DiffusersAttnProcessor2_0
+        ):
+            self.set_processor(AttnProcessor())
+
         return self.processor(
             self,
             hidden_states,


### PR DESCRIPTION
This PR is done:

- [x] Fix: https://github.com/siliconflow/onediff/issues/1105
- [x] 修复 onediff_quant 的 from_pretrained 兼容 diffusers >= 0.29.1: https://github.com/siliconflow/onediff-quant/pull/39

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced attention mechanism to automatically revert to a standard processor when using specific processor types from the `diffusers` library.
	- Introduced new command-line arguments for the text-to-image script: `--compile_text_encoder` and `--graph`, allowing for more flexible model compilation options.

- **Bug Fixes**
	- Improved handling of processor types to ensure better compatibility and functionality within the attention processing framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->