### PR TITLE
Use 122 and install cupti in pro img

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -283,6 +283,7 @@ jobs:
 
       - run: nvidia-smi
       - run: nvidia-smi -L
+      - run: docker exec ${{ env.CONTAINER_NAME }} python3 -m pip list
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 -m oneflow --doctor
       - run: docker exec ${{ env.CONTAINER_NAME }} python3 -m pip config set global.index-url https://pypi.tuna.tsinghua.edu.cn/simple
       - name: Install onediff-quant if needed

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -174,14 +174,14 @@ jobs:
           - ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         image:
           - onediff:cu118
-          - onediff-pro:cu121
+          - onediff-pro:cu122
         test-suite:
           - diffusers_examples
           - comfy
           - webui
         exclude:
           - should-run-pro: false
-            image: onediff-pro:cu121
+            image: onediff-pro:cu122
     steps:
       - name: Login to ACR with the AccessKey pair
         if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/sd.yml
+++ b/.github/workflows/sd.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Set env (Pro)
         if: matrix.image.repo == 'onediff-pro'
         run: |
-          echo ONEFLOW_PIP_INDEX="https://${{ secrets.ONEFLOW_PRIV_OSS_BUCKET }}.oss-cn-beijing.aliyuncs.com/branch/main/cu121" >> $GITHUB_ENV
+          echo ONEFLOW_PIP_INDEX="https://${{ secrets.ONEFLOW_PRIV_OSS_BUCKET }}.oss-cn-beijing.aliyuncs.com/branch/main/cu122" >> $GITHUB_ENV
       - name: Get OneFlow version
         id: get-oneflow-version
         run: |

--- a/.github/workflows/sd.yml
+++ b/.github/workflows/sd.yml
@@ -40,6 +40,11 @@ jobs:
               suffix: "cu121",
               repo: "onediff-pro",
             }
+          - {
+              BASE_IMAGE: "nvcr.io/nvidia/pytorch:23.08-py3",
+              suffix: "cu122",
+              repo: "onediff-pro",
+            }
 
     env:
       DOCKER_BUILDKIT: 1
@@ -79,7 +84,7 @@ jobs:
       - name: Set env (Pro)
         if: matrix.image.repo == 'onediff-pro'
         run: |
-          echo ONEFLOW_PIP_INDEX="https://${{ secrets.ONEFLOW_PRIV_OSS_BUCKET }}.oss-cn-beijing.aliyuncs.com/branch/main/cu122" >> $GITHUB_ENV
+          echo ONEFLOW_PIP_INDEX="https://${{ secrets.ONEFLOW_PRIV_OSS_BUCKET }}.oss-cn-beijing.aliyuncs.com/branch/main/${{ matrix.image.suffix }}" >> $GITHUB_ENV
       - name: Get OneFlow version
         id: get-oneflow-version
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE}
 ARG ONEFLOW_PIP_INDEX
 ARG ONEFLOW_PACKAGE_NAME=oneflow
 RUN pip install -f ${ONEFLOW_PIP_INDEX} ${ONEFLOW_PACKAGE_NAME} "nvidia-cudnn-cu11>=8.9,<9.0"
-RUN python3 -m pip install "torch" "transformers==4.27.1" "diffusers[torch]==0.19.3" "huggingface-hub==0.23.2"
+RUN python3 -m pip install "torch" "transformers==4.27.1" "diffusers[torch]==0.19.3" "huggingface-hub==0.23.2" nvidia-cuda-cupti-cu12
 ADD . /src/onediff
 RUN python3 -m pip install -e /src/onediff
 RUN python3 -m pip install -e /src/onediff/onediff_diffusers_extensions

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM ${BASE_IMAGE}
 ARG ONEFLOW_PIP_INDEX
 ARG ONEFLOW_PACKAGE_NAME=oneflow
 RUN pip install -f ${ONEFLOW_PIP_INDEX} ${ONEFLOW_PACKAGE_NAME} "nvidia-cudnn-cu11>=8.9,<9.0"
-RUN python3 -m pip install "torch" "transformers==4.27.1" "diffusers[torch]==0.19.3" "huggingface-hub==0.23.2" nvidia-cuda-cupti-cu12
+RUN python3 -m pip install "torch" "transformers==4.27.1" "diffusers[torch]==0.19.3" "huggingface-hub==0.23.2" nvidia-cuda-cupti-cu12 nvidia-nvjitlink-cu12
 ADD . /src/onediff
 RUN python3 -m pip install -e /src/onediff
 RUN python3 -m pip install -e /src/onediff/onediff_diffusers_extensions

--- a/README.md
+++ b/README.md
@@ -157,12 +157,12 @@ Install OneFlow is Optional.
 
   For NA/EU users
   ```bash
-  python3 -m pip install -U --pre oneflow -f https://github.com/siliconflow/oneflow_releases/releases/expanded_assets/community_cu121
+  python3 -m pip install -U --pre oneflow -f https://github.com/siliconflow/oneflow_releases/releases/expanded_assets/community_cu122
   ```
 
   For CN users
   ```bash
-  python3 -m pip install -U --pre oneflow -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/branch/community/cu121
+  python3 -m pip install -U --pre oneflow -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/branch/community/cu122
   ```
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the Dockerfile to include support for the NVIDIA CUDA CUPTI library version 12, enhancing performance and compatibility.
	- Enhanced the README with updated installation instructions for OneFlow, reflecting the change to CUDA version 12.2, and improved performance comparisons for various models.
- **Chores**
	- Modified the GitHub Actions workflow to update the `ONEFLOW_PIP_INDEX` environment variable for dynamic versioning of the OneFlow package.
	- Updated CI testing workflow to use the new container image version `onediff-pro:cu122`.
	- Added a command to list installed Python packages in the CI testing workflow for better visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->