### PR TITLE
Use stable-diffusion-xl-base-1.0 to validate graph persistence

### DIFF
--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -296,9 +296,6 @@ jobs:
           docker exec ${{ env.CONTAINER_NAME }} python3 -m pip install -r tests/comfyui/requirements.txt --user
           docker exec ${{ env.CONTAINER_NAME }} python3 -m pip install -r ComfyUI/requirements.txt --user
           docker exec ${{ env.CONTAINER_NAME }} python3 -m pip uninstall -y transformer-engine
-      - name: Print pip package versions
-        run: |
-          docker exec ${{ env.CONTAINER_NAME }} python3 -m pip list
       - name: Start ComfyUI Web Service
         if: matrix.test-suite == 'comfy'
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -178,7 +178,6 @@ jobs:
         test-suite:
           - diffusers_examples
           - comfy
-          - webui
         exclude:
           - should-run-pro: false
             image: onediff-pro:cu122

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -289,7 +289,7 @@ jobs:
       - name: Install onediff-quant if needed
         if: startsWith(matrix.image, 'onediff-pro')
         run: |
-          docker exec ${{ env.CONTAINER_NAME }} python3 -m pip install --pre onediff-quant -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff-quant/
+          docker exec ${{ env.CONTAINER_NAME }} python3 -m pip install --pre onediff-quant "numpy<2" -f https://oneflow-pro.oss-cn-beijing.aliyuncs.com/onediff-quant/
       - name: Pip Install Requirements for ComfyUI & Test
         if: matrix.test-suite == 'comfy'
         run: |

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -359,7 +359,7 @@ jobs:
         run: docker exec -w /src/onediff/onediff_diffusers_extensions ${{ env.CONTAINER_NAME }} bash examples/unet_save_and_load.sh --model_id=/share_nfs/hf_models/stable-diffusion-xl-base-1.0
       - if: matrix.test-suite == 'diffusers_examples'
         run: |
-          docker exec ${{ env.CONTAINER_NAME }} python3 -m pip install --user scikit-image
+          docker exec ${{ env.CONTAINER_NAME }} python3 -m pip install --user scikit-image "numpy<2"
           docker exec -e ONEFLOW_MLIR_ENABLE_INFERENCE_OPTIMIZATION=0 ${{ env.CONTAINER_NAME }} python3 -m pytest -v onediff_diffusers_extensions/tests/test_lora.py --disable-warnings
 
       - name: Install Requirements for WebUI

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -356,7 +356,7 @@ jobs:
       - if: matrix.test-suite == 'diffusers_examples'
         run: docker exec -w /src/onediff/onediff_diffusers_extensions ${{ env.CONTAINER_NAME }} python3 examples/text_to_image_controlnet.py --base=/share_nfs/hf_models/stable-diffusion-v1-5 --controlnet=/share_nfs/hf_models/sd-controlnet-canny --input_image=/share_nfs/hf_models/input_image_vermeer.png
       - if: matrix.test-suite == 'diffusers_examples'
-        run: docker exec -w /src/onediff/onediff_diffusers_extensions ${{ env.CONTAINER_NAME }} bash examples/unet_save_and_load.sh --model_id=/share_nfs/hf_models/stable-diffusion-2-1
+        run: docker exec -w /src/onediff/onediff_diffusers_extensions ${{ env.CONTAINER_NAME }} bash examples/unet_save_and_load.sh --model_id=/share_nfs/hf_models/stable-diffusion-xl-base-1.0
       - if: matrix.test-suite == 'diffusers_examples'
         run: |
           docker exec ${{ env.CONTAINER_NAME }} python3 -m pip install --user scikit-image

--- a/tests/comfy-docker-compose.yml
+++ b/tests/comfy-docker-compose.yml
@@ -29,7 +29,6 @@ services:
       CI: "1"
       SILICON_ONEDIFF_LICENSE_KEY: ${SILICON_ONEDIFF_LICENSE_KEY}
     volumes:
-      - $HOME/test-container-cache-${CONTAINER_NAME}/dot-local:/root/.local
       - $HOME/test-container-cache-${CONTAINER_NAME}/dot-cache:/root/.cache
       - /share_nfs:/share_nfs:ro
       - ${PWD}/${COMFYUI_SRC_DIR}:/app/ComfyUI

--- a/tests/diffusers-docker-compose.yml
+++ b/tests/diffusers-docker-compose.yml
@@ -20,7 +20,6 @@ services:
       CI: "1"
       SILICON_ONEDIFF_LICENSE_KEY: ${SILICON_ONEDIFF_LICENSE_KEY}
     volumes:
-      - $HOME/test-container-cache-${CONTAINER_NAME}/dot-local:/root/.local
       - $HOME/test-container-cache-${CONTAINER_NAME}/dot-cache:/root/.cache
       - /share_nfs:/share_nfs:ro
       - ${SDXL_BASE}:/app/ComfyUI/models/checkpoints/sd_xl_base_1.0.safetensors:ro

--- a/tests/webui-docker-compose.yml
+++ b/tests/webui-docker-compose.yml
@@ -46,7 +46,6 @@ services:
 
 
     volumes:
-      - $HOME/test-container-cache-${CONTAINER_NAME}/dot-local:/root/.local
       - $HOME/test-container-cache-${CONTAINER_NAME}/dot-cache:/root/.cache
       - /share_nfs:/share_nfs:ro
       - /share_nfs/onediff_ci/sd-webui/images:/share_nfs/onediff_ci/sd-webui/images:rw


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the model ID for the `run-examples` job in the workflow configuration.
	- Removed volume mapping for the `onediff-test` service in multiple Docker Compose configuration files, affecting local data storage within containers.
	- Added a constraint for the installation of the `onediff-quant` package to require `"numpy<2"`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->