### PR TITLE
Update the Dockerfile to allow docker to download a sufficiently new version of oneflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM ${BASE_IMAGE}
 
 ARG ONEFLOW_PIP_INDEX
 ARG ONEFLOW_PACKAGE_NAME=oneflow
-RUN pip install -f ${ONEFLOW_PIP_INDEX} ${ONEFLOW_PACKAGE_NAME} "nvidia-cudnn-cu11>=8.9,<9.0"
+RUN pip install -U --pre -f ${ONEFLOW_PIP_INDEX} ${ONEFLOW_PACKAGE_NAME} "nvidia-cudnn-cu11>=8.9,<9.0"
 RUN python3 -m pip install "torch" "transformers==4.27.1" "diffusers[torch]==0.19.3" "huggingface-hub==0.23.2" nvidia-cuda-cupti-cu12 nvidia-nvjitlink-cu12
 ADD . /src/onediff
 RUN python3 -m pip install -e /src/onediff


### PR DESCRIPTION
https://github.com/siliconflow/onediff/issues/395
this issue came from the install of oneflow==0.9, which should be >=0.9.1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the installation command for the `oneflow` package to allow for upgrades and pre-release versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->